### PR TITLE
join/gather

### DIFF
--- a/cowait/__init__.py
+++ b/cowait/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa: F401
 
-from .tasks import Task, rpc, join
+from .tasks import Task, rpc, join, gather

--- a/cowait/tasks/__init__.py
+++ b/cowait/tasks/__init__.py
@@ -10,6 +10,6 @@ from .remote_task import RemoteTask
 from .definition import TaskDefinition
 
 from .flow import Flow
-from .ops import join
+from .ops import join, gather
 
 from .components.rpc import rpc

--- a/cowait/tasks/ops.py
+++ b/cowait/tasks/ops.py
@@ -1,7 +1,13 @@
 import asyncio
 
 
-async def join(*tasks):
+async def join(tasks):
+    return await asyncio.gather(*tasks)
+    done, pending = await asyncio.wait(tasks)
+    return list(done)
+
+
+async def gather(*tasks):
     return await asyncio.gather(*tasks)
     done, pending = await asyncio.wait(tasks)
     return list(done)

--- a/examples/getting-started-parallel/minimum.py
+++ b/examples/getting-started-parallel/minimum.py
@@ -1,0 +1,16 @@
+from cowait import Task, join
+from number import Number
+
+
+class Minimum(Task):
+    async def run(self, first=3, second=5):
+        tasks = [
+            Number(value=first),
+            Number(value=second)
+        ]
+
+        result = min(await join(tasks))
+
+        print('Minimum value:', result)
+
+        return result

--- a/examples/getting-started-sequential/maximum.py
+++ b/examples/getting-started-sequential/maximum.py
@@ -1,0 +1,14 @@
+from cowait import Task
+from number import Number
+
+
+class Maximum(Task):
+    async def run(self, first=3, second=5):
+        a = await Number(value=first)
+        b = await Number(value=second)
+
+        result = max(a, b)
+
+        print('Maximum value:', result)
+
+        return result

--- a/examples/parent.py
+++ b/examples/parent.py
@@ -13,7 +13,7 @@ class Parent(Task):
         # join() waits for a list of tasks to finish
         # it returns their results as a list:
         print('waiting for children to finish...')
-        results = await join(*tasks)
+        results = await join(tasks)
 
         print('all done')
         return results


### PR DESCRIPTION
Changes the behaviour of `join` to accept a list of tasks instead of args spreading.

## Before
`join(*tasks)`

## After
`join(tasks)`


## Added `gather`
For accustomed `asyncio` users, added a `gather` util. `gather` uses the asyncio signature (`gather(*tasks)`).