### PR TITLE
Await orphaned tasks, task failure tests & agent error storage fix

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 100
+exclude =
+    __pycache__,
+    .git,
+    build,
+    cloud,
+    dist

--- a/cowait/engine/test_docker.py
+++ b/cowait/engine/test_docker.py
@@ -116,3 +116,36 @@ def test_docker_child_task():
 
     children = dp.find_child_containers(task.id)
     assert len(children) == 0
+
+
+def test_docker_task_error():
+    dp = DockerProvider()
+
+    task = dp.spawn(TaskDefinition(
+        name=TEST_TASK,
+        image=TEST_IMAGE,
+        inputs={'error': True},
+    ))
+
+    container = dp.docker.containers.get(task.container.id)
+    assert task.container == container
+
+    result = container.wait()
+    assert result['StatusCode'] != 0
+
+
+def test_docker_child_error():
+    dp = DockerProvider()
+
+    task = dp.spawn(TaskDefinition(
+        name=TEST_TASK,
+        image=TEST_IMAGE,
+        inputs={'child_error': True},
+    ))
+
+    container = dp.docker.containers.get(task.container.id)
+    assert task.container == container
+
+    # child error should cause the parent to fail
+    result = container.wait()
+    assert result['StatusCode'] != 0

--- a/cowait/network/client.py
+++ b/cowait/network/client.py
@@ -45,7 +45,7 @@ class Client(EventEmitter):
 
                 # send buffered messages
                 for msg in self.buffer:
-                    self.send(msg)
+                    await self.send(msg)
                 self.buffer = []
 
                 # client loop

--- a/cowait/tasks/remote_task.py
+++ b/cowait/tasks/remote_task.py
@@ -22,6 +22,10 @@ class RemoteTask(TaskDefinition):
     def __await__(self):
         return self.awaitable.__await__()
 
+    @property
+    def done(self):
+        return self.future.done()
+
     def destroy(self):
         self.cluster.destroy(self.id)
 

--- a/cowait/test/tasks/utility_task.py
+++ b/cowait/test/tasks/utility_task.py
@@ -13,7 +13,13 @@ class UtilityTask(Task):
         # store taskdef for later comparison
         self.taskdef = taskdef
 
-    async def run(self, child: bool = False, **inputs):
+    async def run(
+        self,
+        child: bool = False,
+        error: bool = False,
+        child_error: bool = False,
+        **inputs
+    ):
         # dump task information to stdout
         print(json.dumps({
             'taskdef': self.taskdef.serialize(),
@@ -21,9 +27,14 @@ class UtilityTask(Task):
         }))
 
         # create a child
-        if child:
+        if child or child_error:
             print('spawn child')
-            await self.spawn('cowait.test.tasks.utility_task', inputs={'child': False})
+            await self.spawn(
+                'cowait.test.tasks.utility_task',
+                inputs={'error': child_error})
+
+        if error:
+            raise RuntimeError('Caused test error')
 
         # run forever
         if inputs.get('forever', False):

--- a/cowait/utils/emitter.py
+++ b/cowait/utils/emitter.py
@@ -5,7 +5,7 @@ class EventEmitter(object):
 
     def on(self, type: str, callback: callable) -> None:
         try:
-            self.callbacks[type].append(callback)
+            self.callbacks[type].insert(0, callback)
         except KeyError:
             self.callbacks[type] = [callback]
 

--- a/cowait/worker/executor.py
+++ b/cowait/worker/executor.py
@@ -70,6 +70,12 @@ async def execute(cluster: ClusterProvider, taskdef: TaskDefinition) -> None:
             # execute task
             result = await task.run(**inputs)
 
+            # wait for dangling tasks
+            orphans = filter(lambda child: not child.done, task.subtasks.values())
+            for orphan in orphans:
+                print('~~ waiting for orphaned task', orphan.id)
+                await orphan
+
             # after hook
             await task.after(inputs)
 
@@ -86,7 +92,7 @@ async def execute(cluster: ClusterProvider, taskdef: TaskDefinition) -> None:
     except TaskError as e:
         # pass subtask errors upstream
         await node.parent.send_fail(
-            f'Caught exception in {taskdef.id}:\n'
+            f'Caught exception in subtask {taskdef.id}:\n'
             f'{e.error}')
         raise e
 

--- a/cowait/worker/executor.py
+++ b/cowait/worker/executor.py
@@ -88,6 +88,7 @@ async def execute(cluster: ClusterProvider, taskdef: TaskDefinition) -> None:
         await node.parent.send_fail(
             f'Caught exception in {taskdef.id}:\n'
             f'{e.error}')
+        raise e
 
     except Exception as e:
         # capture local errors


### PR DESCRIPTION
- Added tests for failed tasks (DockerProvider)
- Await orphaned subtasks after execution
- Agent properly stores task errors
- Set max line witdth to 100 chars

resolve #97 
resolve #55 