### PR TITLE
Kubernetes: move wait_until_ready from spawn() to logs()

### DIFF
--- a/cowait/engine/kubernetes.py
+++ b/cowait/engine/kubernetes.py
@@ -102,9 +102,6 @@ class KubernetesProvider(ClusterProvider):
                 ),
             )
 
-            # wait for pod to become ready
-            self.wait_until_ready(taskdef.id)
-
             # wrap & return task
             print('~~ created kubenetes pod', pod.metadata.name)
             task = KubernetesTask(self, taskdef, pod)
@@ -185,6 +182,9 @@ class KubernetesProvider(ClusterProvider):
                 raise TimeoutError(f'Could not find pod for {task_id}')
 
     def logs(self, task: KubernetesTask):
+        # wait for pod to become ready
+        self.wait_until_ready(task.id)
+
         try:
             w = watch.Watch()
             return w.stream(


### PR DESCRIPTION
Fixes a bug where short lived containers would never be marked as completed because they finish before the `KubernetesProvider.spawn()` call returns.

`spawn()` no longer waits for the pod to become ready, which is likely fine since we have timeout logic elsewhere. `logs()` still need the pod to be ready however (otherwise kubernetes throws an error) so the `wait_until_ready()` call has been moved there.