### PR TITLE
Type Descriptions

### DIFF
--- a/cowait/types/__init__.py
+++ b/cowait/types/__init__.py
@@ -3,6 +3,7 @@
 from .type import Type
 from .dict import Dict
 from .list import List
+from .custom import CustomType
 from .simple import Any, String, Int, Float, Bool
 from .mapping import TypeAlias
 

--- a/cowait/types/custom.py
+++ b/cowait/types/custom.py
@@ -6,25 +6,17 @@ class CustomType(Type):
         self.cls = cls
         self.shape = shape
 
-    def describe(self):
-        return {
-            key: type.name
-            for key, type in self.shape.items()
-        }
-
     def validate(self, value):
         if not isinstance(value, dict):
             raise TypeError('Expected a dict')
         for key, type in self.shape.items():
-            type.validate(value['key'])
+            type.validate(value[key])
 
     def serialize(self, value):
-        data = {
+        return {
             key: type.serialize(getattr(value, key))
             for key, type in self.shape.items()
         }
-        data['@'] = self.name
-        return data
 
     def deserialize(self, value):
         return self.cls(**{

--- a/cowait/types/custom.py
+++ b/cowait/types/custom.py
@@ -1,0 +1,33 @@
+from .type import Type
+
+
+class CustomType(Type):
+    def __init__(self, cls, shape: dict):
+        self.cls = cls
+        self.shape = shape
+
+    def describe(self):
+        return {
+            key: type.name
+            for key, type in self.shape.items()
+        }
+
+    def validate(self, value):
+        if not isinstance(value, dict):
+            raise TypeError('Expected a dict')
+        for key, type in self.shape.items():
+            type.validate(value['key'])
+
+    def serialize(self, value):
+        data = {
+            key: type.serialize(getattr(value, key))
+            for key, type in self.shape.items()
+        }
+        data['@'] = self.name
+        return data
+
+    def deserialize(self, value):
+        return self.cls(**{
+            key: type.deserialize(value[key])
+            for key, type in self.shape.items()
+        })

--- a/cowait/types/dict.py
+++ b/cowait/types/dict.py
@@ -36,3 +36,14 @@ class Dict(Type):
             key: type.deserialize(value[key])
             for key, type in self.shape.items()
         }
+
+    def describe(self):
+        desc = {}
+        for key, type in self.shape.items():
+            type_desc = type.describe()
+            if type_desc is not None:
+                desc[key] = type_desc
+        return desc
+
+    def __getitem__(self, key):
+        return self.shape[key]

--- a/cowait/types/list.py
+++ b/cowait/types/list.py
@@ -25,3 +25,9 @@ class List(Type):
 
     def deserialize(self, value: list) -> list:
         return [self.elementType.deserialize(item) for item in value]
+
+    def describe(self):
+        item_desc = self.elementType.describe()
+        if item_desc is not None:
+            return [item_desc]
+        return []

--- a/cowait/types/mapping.py
+++ b/cowait/types/mapping.py
@@ -5,12 +5,24 @@ from .type import Type
 
 
 _type_mapping = {}
+_name_mapping = {}
 
 
 def register_type(from_type: ClassVar, to_type: Type) -> None:
     """ Registers a type alias for the given from_type """
+    global _name_mapping
     global _type_mapping
+    if to_type.name is None:
+        to_type.name = f'{to_type.__module__}.{to_type.__name__}'
+    _name_mapping[to_type.name] = to_type
     _type_mapping[from_type] = to_type
+
+
+def get_type(name: str) -> Type:
+    global _name_mapping
+    if name in _name_mapping:
+        return _name_mapping[name]
+    raise TypeError(f'Unknown type {name}')
 
 
 def TypeAlias(alias: ClassVar):

--- a/cowait/types/simple.py
+++ b/cowait/types/simple.py
@@ -5,6 +5,9 @@ from .mapping import TypeAlias
 @TypeAlias(any)
 class Any(Type):
     """ Any type. Disables typechecking. """
+
+    name: str = 'any'
+
     def validate(self, value: any, name: str) -> None:
         pass
 
@@ -12,6 +15,9 @@ class Any(Type):
 @TypeAlias(int)
 class Int(Type):
     """ Integer, or anything that can be cast to an integer """
+
+    name: str = 'int'
+
     def validate(self, value: int, name: str) -> None:
         try:
             int(value)
@@ -25,6 +31,8 @@ class Int(Type):
 @TypeAlias(float)
 class Float(Type):
     """ Floating point, or anything that can be cast to a float """
+
+    name: str = 'float'
 
     def validate(self, value: float, name: str) -> None:
         try:
@@ -40,6 +48,8 @@ class Float(Type):
 class String(Type):
     """ String """
 
+    name: str = 'str'
+
     def validate(self, value: str, name: str) -> None:
         try:
             str(value)
@@ -53,6 +63,8 @@ class String(Type):
 @TypeAlias(bool)
 class Bool(Type):
     """ Boolean """
+
+    name: str = 'bool'
 
     def validate(self, value: bool, name: str) -> None:
         if isinstance(value, bool):

--- a/cowait/types/test_serialization.py
+++ b/cowait/types/test_serialization.py
@@ -1,0 +1,54 @@
+from .dict import Dict
+from .list import List
+from .custom import CustomType
+from .simple import Int, String
+from .mapping import TypeAlias
+from .utils import type_from_description
+
+
+def test_deserialize_dict_type():
+    desc = type_from_description({
+        'text': 'str',
+        'number': 'int',
+    })
+    assert isinstance(desc, Dict)
+    assert isinstance(desc['text'], String)
+    assert isinstance(desc['number'], Int)
+
+
+def test_deserialize_list_type():
+    desc = type_from_description(['str'])
+    assert isinstance(desc, List)
+    assert isinstance(desc.elementType, String)
+
+
+class ComplexCustom(object):
+    def __init__(self, text, number):
+        self.text = text
+        self.number = number
+
+
+@TypeAlias(ComplexCustom)
+class ComplexCustomType(CustomType):
+    def __init__(self):
+        super().__init__(ComplexCustom, {
+            'text': String(),
+            'number': Int(),
+        })
+
+
+def test_custom_type_serialization():
+    obj = ComplexCustom(text='hej', number=3)
+    type = ComplexCustomType()
+    desc = type.describe()
+    assert 'text' in desc and desc['text'] == String.name
+    assert 'number' in desc and desc['number'] == Int.name
+
+    data = type.serialize(obj)
+    assert '@' in data and data['@'] == type.name
+    assert 'text' in data and data['text'] == obj.text
+    assert 'number' in data and data['number'] == obj.number
+
+    obj2 = type.deserialize(data)
+    assert obj2.text == obj.text
+    assert obj2.number == obj.number

--- a/cowait/types/test_serialization.py
+++ b/cowait/types/test_serialization.py
@@ -30,6 +30,8 @@ class ComplexCustom(object):
 
 @TypeAlias(ComplexCustom)
 class ComplexCustomType(CustomType):
+    name = 'ComplexCustomType'
+
     def __init__(self):
         super().__init__(ComplexCustom, {
             'text': String(),
@@ -40,15 +42,18 @@ class ComplexCustomType(CustomType):
 def test_custom_type_serialization():
     obj = ComplexCustom(text='hej', number=3)
     type = ComplexCustomType()
+
     desc = type.describe()
-    assert 'text' in desc and desc['text'] == String.name
-    assert 'number' in desc and desc['number'] == Int.name
+    assert desc == 'ComplexCustomType'
 
     data = type.serialize(obj)
-    assert '@' in data and data['@'] == type.name
     assert 'text' in data and data['text'] == obj.text
     assert 'number' in data and data['number'] == obj.number
 
-    obj2 = type.deserialize(data)
+    # the custom type should be available from the type registry
+    # ensure deserialization yields a proper object with the expected values
+    type2 = type_from_description(type.name)
+    obj2 = type2.deserialize(data)
+    assert isinstance(obj2, ComplexCustom)
     assert obj2.text == obj.text
     assert obj2.number == obj.number

--- a/cowait/types/test_types.py
+++ b/cowait/types/test_types.py
@@ -1,5 +1,5 @@
 import pytest
-from .mapping import is_cowait_type, convert_type
+from .mapping import is_cowait_type, convert_type, get_type
 from .simple import Any, String, Int, Float, Bool
 from .dict import Dict
 from .list import List
@@ -181,3 +181,8 @@ def test_instantiate_with_default_params():
     obj = convert_type(TypeWithParam)
     assert isinstance(obj, TypeWithParam)
     assert obj.a == 1
+
+
+def test_get_type():
+    assert get_type('str') is String
+    assert get_type('int') is Int

--- a/cowait/types/test_utils.py
+++ b/cowait/types/test_utils.py
@@ -1,7 +1,6 @@
 from .dict import Dict
 from .simple import Any, Int
-from .utils import get_return_type, \
-    get_parameter_types, get_parameter_defaults
+from .utils import get_return_type, get_parameter_types, get_parameter_defaults
 
 
 def test_get_parameter_defaults():

--- a/cowait/types/type.py
+++ b/cowait/types/type.py
@@ -5,6 +5,8 @@ from abc import ABC, abstractmethod
 class Type(ABC):
     """ Abstract base class for all Cowait types. """
 
+    name: str = None
+
     @abstractmethod
     def validate(self, value: any, name: str) -> None:
         """ Validates a value as this type. Raises ValueError if invalid """
@@ -17,3 +19,8 @@ class Type(ABC):
     def deserialize(self, value: any) -> Type:
         """ Deserializes a JSON representation of a value """
         return value
+
+    def describe(self):
+        if self.name is None:
+            raise TypeError('Unnamed type')
+        return self.name

--- a/cowait/types/utils.py
+++ b/cowait/types/utils.py
@@ -1,8 +1,9 @@
 import inspect
 from .type import Type
 from .simple import Any
+from .list import List
 from .dict import Dict
-from .mapping import convert_type
+from .mapping import get_type, convert_type
 
 
 def convert_type_annotation(annot: object) -> Type:
@@ -41,3 +42,29 @@ def get_parameter_types(func: callable) -> Type:
         for key, parameter in sig.parameters.items()
         if parameter.kind == inspect._POSITIONAL_OR_KEYWORD
     })
+
+
+def type_from_description(desc: any) -> Type:
+    if isinstance(desc, dict):
+        if '@' in desc:
+            CustomType = get_type(desc['@'])
+            del desc['@']
+            return CustomType(**desc)
+        else:
+            return Dict({
+                key: type_from_description(typedesc)
+                for key, typedesc in desc.items()
+            })
+    elif isinstance(desc, list):
+        if len(desc) == 0:
+            return List()
+        elif len(desc) == 1:
+            list_type = type_from_description(desc[0])
+            return List(list_type)
+        else:
+            raise TypeError('List typedef should contain a single item')
+    elif isinstance(desc, str):
+        # it should be a type name!
+        return get_type(desc)()
+    else:
+        raise TypeError('Invalid type description')

--- a/cowait/types/utils.py
+++ b/cowait/types/utils.py
@@ -46,15 +46,10 @@ def get_parameter_types(func: callable) -> Type:
 
 def type_from_description(desc: any) -> Type:
     if isinstance(desc, dict):
-        if '@' in desc:
-            CustomType = get_type(desc['@'])
-            del desc['@']
-            return CustomType(**desc)
-        else:
-            return Dict({
-                key: type_from_description(typedesc)
-                for key, typedesc in desc.items()
-            })
+        return Dict({
+            key: type_from_description(typedesc)
+            for key, typedesc in desc.items()
+        })
     elif isinstance(desc, list):
         if len(desc) == 0:
             return List()


### PR DESCRIPTION
Cowait Types must be serializable themselves. This allows us to return complex custom types from tasks and RPC calls.

This PR implements a _type description_ that can be returned along with a value. This description allows the type system to deserialize the type itself, and use this type to deserialize the value. If the type is not known to the caller, an error will be thrown.

**Example**
```js
{
  // task data...
  "result": {
    "spark": {
      "master_uri": "spark://whatever"
    }
  },
  "result_type": {
    "spark": "cowait.spark.types.SparkContext"
  }
}
```

Because the `cowait.spark.types.SparkContext` type is built in (and thus always known to the caller), a `SparkContext` object can be passed directly between tasks without manual serialization.