### PR TITLE
Volume Mount Support

### DIFF
--- a/bin/cowait
+++ b/bin/cowait
@@ -120,7 +120,6 @@ def run(
         ctx.obj,
         task,
         name=name,
-        cluster_name=cluster,
         inputs={
             **file_inputs,
             **option_dict(input),

--- a/cowait/cli/commands/run.py
+++ b/cowait/cli/commands/run.py
@@ -13,7 +13,6 @@ def run(
     config: CowaitConfig,
     task: str,
     name: str = None,
-    cluster_name: str = None,
     inputs: dict = {},
     env: dict = {},
     ports: dict = {},

--- a/cowait/engine/errors.py
+++ b/cowait/engine/errors.py
@@ -3,5 +3,6 @@
 class TaskCreationError(RuntimeError):
     pass
 
+
 class ProviderError(RuntimeError):
     pass

--- a/cowait/engine/kubernetes.py
+++ b/cowait/engine/kubernetes.py
@@ -61,6 +61,9 @@ class KubernetesProvider(ClusterProvider):
         try:
             self.emit_sync('prepare', taskdef=taskdef)
 
+            if len(taskdef.volumes.keys()) > 0:
+                print('!! warning: kubernetes provider does not support volumes')
+
             # container definition
             container = client.V1Container(
                 name=taskdef.id,

--- a/cowait/tasks/definition.py
+++ b/cowait/tasks/definition.py
@@ -93,8 +93,7 @@ class TaskDefinition(object):
         elif isinstance(created_at, str):
             self.created_at = datetime.fromisoformat(created_at)
         else:
-            print('created_at', created_at)
-            raise TypeError('Expected created_at to be None or datetime')
+            raise TypeError(f'Expected created_at to be None or datetime, got {created_at}')
 
     def serialize(self) -> dict:
         """ Serialize task definition to a dict """

--- a/cowait/tasks/definition.py
+++ b/cowait/tasks/definition.py
@@ -28,6 +28,12 @@ class TaskDefinition(object):
         meta (dict): Freeform metadata
         env (dict): Environment variables
         ports (dict): Port forwards
+        routes (dict): HTTP Ingresses
+        volumes (dict): List of volumes
+        cpu (str): CPU allocation
+        memory (str): Memory allocation
+        owner (str): Owner name
+        created_at (DateTime): Creation date
     """
 
     def __init__(
@@ -42,6 +48,7 @@ class TaskDefinition(object):
         env:       dict = {},
         ports:     dict = {},
         routes:    dict = {},
+        volumes:   dict = {},
         cpu:       str = '0',
         memory:    str = '0',
         owner:     str = '',
@@ -57,11 +64,12 @@ class TaskDefinition(object):
             meta (dict): Freeform metadata
             env (dict): Environment variables
             ports (dict): Port forwards
-            routes (dict)
-            cpu (str)
-            memory (str)
-            owner (str)
-            created_at (DateTime)
+            routes (dict): HTTP Ingresses
+            volumes (dict): List of volumes
+            cpu (str): CPU allocation
+            memory (str): Memory allocation
+            owner (str): Owner name
+            created_at (DateTime): Creation date
         """
         self.id = generate_task_id(name) if not id else id
         self.name = name
@@ -76,6 +84,7 @@ class TaskDefinition(object):
         self.cpu = cpu
         self.memory = memory
         self.owner = owner
+        self.volumes = volumes
 
         if created_at is None:
             self.created_at = datetime.now(timezone.utc)
@@ -118,6 +127,11 @@ class TaskDefinitionSchema(Schema):
     result = fields.Raw(allow_none=True)
     log = fields.Str(allow_none=True)
     created_at = fields.DateTime('iso', default=lambda: datetime.now(timezone.utc))
+    volumes = fields.Mapping(
+        keys=fields.Str(),
+        values=fields.Mapping(),
+        missing={}
+    )
 
     @post_load
     def make_taskdef(self, data: dict, **kwargs) -> TaskDefinition:

--- a/cowait/tasks/task.py
+++ b/cowait/tasks/task.py
@@ -84,6 +84,7 @@ class Task(TaskDefinition):
         inputs: dict = {},
         meta: dict = {},
         env: dict = {},
+        volumes: dict = {},
         cpu: str = '0',
         memory: str = '0',
         owner: str = '',
@@ -115,6 +116,10 @@ class Task(TaskDefinition):
             cpu=cpu,
             memory=memory,
             owner=owner,
+            volumes={
+                **self.volumes,
+                **volumes,
+            },
             inputs={
                 **inputs,
                 **kwargs,

--- a/cowait/tasks/test_task_definition.py
+++ b/cowait/tasks/test_task_definition.py
@@ -12,6 +12,7 @@ def test_taskdef_serialization():
         'inputs':     {},
         'ports':      {},
         'routes':     {},
+        'volumes':    {},
         'upstream':   None,
         'created_at': '2020-02-02T20:00:02+00:00',
         'cpu':        '0',


### PR DESCRIPTION
- Generic way to define volumes between docker & kubernetes
- Support for `bind` and `tmpfs` volumes in docker
- Auto mount task context directory
- Volume configuration in cowait context

```yml
version: 1
cowait:
  volumes:
    /var/dst/path:
      bind:
        src: /host/path
        mode: 'ro'
    /var/other:
      bind: /hello
```

resolve #52 