### PR TITLE
Enable WSL2 use of cowait

### DIFF
--- a/cowait/cli/commands/run.py
+++ b/cowait/cli/commands/run.py
@@ -1,5 +1,5 @@
-import os
 import sys
+import getpass
 from cowait.tasks import TaskDefinition
 from cowait.engine.errors import TaskCreationError, ProviderError
 from cowait.utils import parse_task_image_name
@@ -53,7 +53,7 @@ def run(
             routes=routes,
             upstream=context.coalesce('upstream', upstream, agent),
             parent=None,  # root task
-            owner=os.getlogin(),
+            owner=getpass.getuser(),
             cpu=cpu,
             memory=memory,
         )

--- a/cowait/engine/test_docker.py
+++ b/cowait/engine/test_docker.py
@@ -43,10 +43,8 @@ def test_create_docker_task():
     assert task.container == container
 
     # make sure container is properly labeled
-    assert container.labels == {
-        LABEL_TASK_ID: task.id,
-        LABEL_PARENT_ID: 'parent',
-    }
+    assert container.labels[LABEL_TASK_ID] == task.id 
+    assert container.labels[LABEL_PARENT_ID] == 'parent'
 
     # wait for container to execute
     result = container.wait()


### PR DESCRIPTION
Cowait has probably not been tested on WSL2, where things might be a little bit different. I made two small changes that enabled tests and examples to run on my wsl2 setup. 