### PR TITLE
Task workdir setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,6 @@ COPY . .
 
 # move to task directory
 WORKDIR /var/task
+
+ENV PYTHONPATH="/var/task:${PYTHONPATH}"
 CMD [ "python3", "-Bum", "cowait.exec" ]

--- a/bin/cowait
+++ b/bin/cowait
@@ -221,8 +221,12 @@ def agent(ctx, cluster: str, detach: bool, upstream: str):
 
 
 @cli.command(help='build a task')
-def build():
-    cowait.cli.build()
+@click.option('-w', '--workdir',
+              default=None,
+              type=str,
+              help='task working directory')
+def build(workdir: str):
+    cowait.cli.build(workdir)
 
 
 @cli.command(help='push a task to the registry')

--- a/cowait/cli/context.py
+++ b/cowait/cli/context.py
@@ -16,6 +16,10 @@ class CowaitContext(object):
     def __getitem__(self, key: str) -> any:
         return self.get(key, required=True)
 
+    @property
+    def workdir(self) -> str:
+        return self.get('workdir', '.')
+
     def get(self, key: str, default: any = None, required: bool = True):
         path = None
         if isinstance(key, str):
@@ -41,7 +45,7 @@ class CowaitContext(object):
         """
         Find a file within the task context and return its full path
         """
-        path = os.path.join(self.root_path, file_name)
+        path = os.path.join(self.root_path, self.workdir, file_name)
         if not os.path.isfile(path):
             return None
         return path

--- a/cowait/cli/task_image.py
+++ b/cowait/cli/task_image.py
@@ -27,6 +27,13 @@ class Dockerfile(object):
     def __str__(self):
         return '\n'.join(self.lines)
 
+    @staticmethod
+    def read(path):
+        with open(path, 'r') as f:
+            df = Dockerfile('none')
+            df.lines = f.readlines()
+            return df
+
 
 class BuildError(RuntimeError):
     pass

--- a/cowait/cli/task_image.py
+++ b/cowait/cli/task_image.py
@@ -1,3 +1,5 @@
+import os
+import os.path
 import docker
 from .context import CowaitContext
 
@@ -18,6 +20,9 @@ class Dockerfile(object):
 
     def run(self, cmd):
         self.lines.append(f'RUN {cmd}')
+
+    def workdir(self, path):
+        self.lines.append(f'WORKDIR {path}')
 
     def __str__(self):
         return '\n'.join(self.lines)
@@ -49,6 +54,10 @@ class TaskImage(object):
 
         # copy source code
         df.copy('.', '.')
+
+        workdir = self.context.workdir
+        if workdir != '.':
+            df.workdir(os.path.join('/var/task', workdir))
 
         return TaskImage.build_image(
             dockerfile=str(df),

--- a/cowait/cli/test_context.py
+++ b/cowait/cli/test_context.py
@@ -41,6 +41,13 @@ def test_get_values():
         assert context['undefined.undefined']
 
 
+def test_set_values():
+    context = CowaitContext('', {})
+    context['nested.key'] = 1
+    assert isinstance(context.definition['nested'], dict)
+    assert context.definition['nested']['key'] == 1
+
+
 def test_get_files():
     context = CowaitContext.open('test')
 

--- a/cowait/cli/test_context.py
+++ b/cowait/cli/test_context.py
@@ -47,5 +47,5 @@ def test_get_files():
     # context files
     path_abs = context.file('Dockerfile')
     path_rel = context.file_rel('Dockerfile')
-    assert path_abs == os.path.join(context.root_path, 'Dockerfile')
+    assert path_abs == os.path.join(context.root_path, context.get('workdir', '.'), 'Dockerfile')
     assert path_rel == 'Dockerfile'


### PR DESCRIPTION
Allows tasks to run from a subdirectory of the task image context. Everything in the context (defined as the folder containing `cowait.yml`) will still be copied into the `/var/task` folder of the image, but the working directory will be set to the specified subdirectory. This makes it possible to keep cowait tasks out of the project root. When the working directory option is set, both the project root and the working directory will be added to the `PYTHONPATH`.

**Example project structure:**
```
/root/
  /other/
    ...
  /tasks/
    Dockerfile
    task1.py
  cowait.yml
  README.md
```

```yml
# /root/cowait.yml
version: 1
cowait:
  workdir: tasks
```

```
$ pwd
/root/
$ cowait run task1
```