### PR TITLE
WIP: Enable separate task path and image build/runtime

### DIFF
--- a/bin/cowait
+++ b/bin/cowait
@@ -95,12 +95,20 @@ def new_context(name: str, image: str, base: str, cluster_name: str):
               help='yaml/json file with inputs', 
               type=str, 
               default=None)
+@click.option('--task-path',
+              default=None,
+              type=str,
+              help='path to task')
+@click.option('--image-runtime-path',
+              default=None,
+              type=str,
+              help='specifies what path the image should be built and run in')
 @click.pass_context
 def run(
     ctx, task: str, cluster: str, name: str,
     input, env, port, route,
     upstream: str, build: bool, detach: bool,
-    file: str,
+    file: str, task_path: str, image_runtime_path : str,
 ):
     if cluster is not None:
         ctx.obj.default_cluster = cluster
@@ -130,6 +138,8 @@ def run(
         upstream=upstream,
         build=build,
         detach=detach,
+        task_path=task_path,
+        image_runtime_path=image_runtime_path
     )
 
 
@@ -211,8 +221,16 @@ def agent(ctx, cluster: str, detach: bool, upstream: str):
 
 
 @cli.command(help='build a task')
-def build():
-    cowait.cli.build()
+@click.option('--task-path',
+              default=None,
+              type=str,
+              help='path to task')
+@click.option('--image-runtime-path',
+              default=None,
+              type=str,
+              help='specifies what path the image should be built in')
+def build(task_path : str, image_runtime_path : str):
+    cowait.cli.build(task_path=task_path, image_runtime_path=image_runtime_path)
 
 
 @cli.command(help='push a task to the registry')

--- a/cowait/cli/commands/build.py
+++ b/cowait/cli/commands/build.py
@@ -1,22 +1,24 @@
 import os.path
+import sys
 import docker.errors
 import docker.credentials.errors
 from cowait.utils.const import DEFAULT_BASE_IMAGE
 from ..task_image import TaskImage
 from ..context import CowaitContext
-from ..utils import printheader
+from ..utils import printheader, parse_path
 
 
-def build() -> TaskImage:
+def build(task_path: str = None, image_runtime_path: str = None) -> TaskImage:
     try:
-        context = CowaitContext.open()
+        context = CowaitContext.open(parse_path(task_path), parse_path(image_runtime_path))    
         image = TaskImage.open(context)
         print('context path:', context.root_path)
+        print('context image_runtime_path:', context.image_runtime_path)
         print('image:', image.name)
 
         # find task-specific requirements.txt
         # if it exists, it will be copied to the container, and installed
-        requirements = context.file_rel('requirements.txt')
+        requirements = context.file_rel_image_runtime_path('requirements.txt')
         if requirements:
             print('found custom requirements.txt')
 

--- a/cowait/cli/context.py
+++ b/cowait/cli/context.py
@@ -9,9 +9,10 @@ client = docker.from_env()
 
 
 class CowaitContext(object):
-    def __init__(self, root_path: str, definition: dict):
+    def __init__(self, root_path: str, definition: dict, image_runtime_path : str=None):
         self.root_path = root_path
         self.definition = definition
+        self.image_runtime_path = image_runtime_path if image_runtime_path != None else root_path
 
     def __getitem__(self, key: str) -> any:
         return self.get(key, required=True)
@@ -55,6 +56,15 @@ class CowaitContext(object):
             return None
         return self.relpath(abs_path)
 
+    def file_rel_image_runtime_path(self, file_name: str) -> str:
+        """
+        Finds a file in relation to root_path and returns the relative path to image_runtime_path
+        """
+        abs_path = self.file(file_name)
+        if not abs_path:
+            return None
+        return os.path.relpath(abs_path, self.image_runtime_path)
+
     def relpath(self, context_path: str):
         """
         Returns a path relative to the context root
@@ -79,7 +89,7 @@ class CowaitContext(object):
         return self.get('image', os.path.basename(self.root_path))
 
     @staticmethod
-    def open(path: str = None):
+    def open(path: str = None, image_runtime_path : str = None):
         if path is None:
             path = os.getcwd()
 
@@ -94,6 +104,7 @@ class CowaitContext(object):
             return CowaitContext(
                 root_path=os.path.abspath(path),
                 definition={},
+                image_runtime_path=image_runtime_path,
             )
 
         # load context yaml definition
@@ -110,4 +121,5 @@ class CowaitContext(object):
         return CowaitContext(
             root_path=root_path,
             definition=context,
+            image_runtime_path=image_runtime_path,
         )

--- a/cowait/cli/utils.py
+++ b/cowait/cli/utils.py
@@ -72,3 +72,22 @@ def printheader(title: str = None) -> None:
         print(f'--'.ljust(HEADER_WIDTH, '-'))
     else:
         print(f'-- {title} '.upper().ljust(HEADER_WIDTH, '-'))
+
+def parse_path(path: str) -> str:
+    """Parses path, validates it, and joins it with cwd
+
+    Args:
+        path (str): path to be parsed.
+
+    Returns:
+        str: output path, joined with cwd
+    """    
+
+    if(path != None):
+        if(os.path.isdir(path)):
+            path = os.path.join(os.getcwd(), path.strip("/"))
+        else:
+            print('not a valid path:', path)
+            path = None
+
+    return path


### PR DESCRIPTION
These options are added to the cle through
--task-path (path of the task)
--image-runtime-path (bath of image build and run)
If none of these args are give, everything should
run as normal