### PR TITLE
Improved Stopping, Agent Tweaks etc

### DIFF
--- a/cowait/cli/commands/agent.py
+++ b/cowait/cli/commands/agent.py
@@ -22,6 +22,10 @@ def agent(
         if cluster.type == 'api':
             raise CliError('Error: Cant deploy agent using an API cluster')
 
+        token = uuid()
+        if cluster.type == 'docker':
+            token = ''
+
         cluster.destroy('agent')
 
         # create task definition
@@ -34,7 +38,7 @@ def agent(
                 '/': 80,
             },
             meta={
-                'http_token': uuid(),
+                'http_token': token,
             },
         )
 

--- a/cowait/engine/routers/local_port_router.py
+++ b/cowait/engine/routers/local_port_router.py
@@ -15,6 +15,9 @@ class LocalPortRouter(Router):
                 continue
 
             host_port = random.randint(60000, 65000)
+            if taskdef.name == 'cowait.tasks.agent':
+                host_port = 1339
+
             url = f'http://localhost:{host_port}/'
 
             # assign route url

--- a/cowait/engine/routers/traefik2_router.py
+++ b/cowait/engine/routers/traefik2_router.py
@@ -122,7 +122,7 @@ class Traefik2Router(Router):
             pass
 
         try:
-            self.cluster.custom.delete_cluster_custom_object_0(
+            self.cluster.custom.delete_cluster_custom_object(
                 group=TRAEFIK2_API_GROUP,
                 version=TRAEFIK2_API_VERSION,
                 plural=TRAEFIK2_INGRESSROUTE_PLURAL,

--- a/cowait/network/auth_middleware.py
+++ b/cowait/network/auth_middleware.py
@@ -5,6 +5,7 @@ from cowait.utils import uuid
 class AuthMiddleware(object):
     def __init__(self):
         self.tokens = {}
+        self.enabled = True
 
     def add_token(self, token: str) -> None:
         self.tokens[token] = True
@@ -21,6 +22,9 @@ class AuthMiddleware(object):
         return self.tokens.get(token, False)
 
     def is_public(self, path):
+        if not self.enabled:
+            return True
+
         if path == '/ws':
             return False
         if path.startswith('/api/'):

--- a/cowait/tasks/agent/agent.py
+++ b/cowait/tasks/agent/agent.py
@@ -25,6 +25,9 @@ class Agent(Task):
         self.subs.on('subscribe', send_state)
 
         self.token = self.meta['http_token']
+        if self.token is None or self.token == '':
+            self.node.http.auth.enabled = False
+            self.token = 'none'
 
         # create http server
         self.node.http.add_routes(TaskAPI(self).routes('/api/1/tasks'))

--- a/cowait/tasks/agent/agent.py
+++ b/cowait/tasks/agent/agent.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from cowait.tasks import Task, TaskDefinition, sleep, rpc
 from cowait.network import Conn, get_local_connstr
 from cowait.tasks.status import FAIL, WAIT, WORK, STOP
-from cowait.tasks.messages import TASK_INIT, TASK_STATUS, TASK_FAIL, TASK_RETURN
+from cowait.tasks.messages import TASK_INIT, TASK_STATUS, TASK_FAIL
 from .tasklist import TaskList
 from .subscriptions import Subscriptions
 from .api import Dashboard, TaskAPI
@@ -70,7 +70,7 @@ class Agent(Task):
     @rpc
     async def destroy_all(self) -> None:
         for id, task in self.tasks.items():
-            if task.status == WORK or task.status == WORK:
+            if task.status == WAIT or task.status == WORK:
                 await self.emulate_stop(id)
         self.cluster.destroy_all()
 
@@ -131,24 +131,8 @@ class Agent(Task):
         return task.serialize()
 
     async def emulate_stop(self, task_id: str):
-        # update task state record
-        await self.tasks.on_status(None, id=task_id, status=STOP)
-
-        # emulate stop messages to parent
-        await self.node.parent.msg(type=TASK_STATUS, id=task_id, status=STOP)
-
-        # emulate stop messages to subscribers
-        await self.subs.forward(None, id=task_id, type=TASK_STATUS, status=STOP)
+        await self.node.children.emit(type=TASK_STATUS, id=task_id, status=STOP, conn=None)
 
     async def emulate_error(self, task_id: str, error: str):
-        # update task state record
-        await self.tasks.on_status(None, id=task_id, status=FAIL)
-        await self.tasks.on_fail(None, id=task_id, error=error)
-
-        # emulate failure messages to parent
-        await self.node.parent.msg(type=TASK_STATUS, id=task_id, status=FAIL)
-        await self.node.parent.msg(type=TASK_FAIL, id=task_id, error=error)
-
-        # emulate failure messages to subscribers
-        await self.subs.forward(None, id=task_id, type=TASK_FAIL, error=error)
-        await self.subs.forward(None, id=task_id, type=TASK_STATUS, status=FAIL)
+        await self.node.children.emit(type=TASK_STATUS, id=task_id, status=FAIL, conn=None)
+        await self.node.children.emit(type=TASK_FAIL, id=task_id, error=error, conn=None)

--- a/cowait/tasks/components/rpc.py
+++ b/cowait/tasks/components/rpc.py
@@ -1,7 +1,7 @@
 import inspect
 import traceback
 from aiohttp import web
-from cowait.types import typed_async_call, get_return_type
+from cowait.types import typed_async_call
 
 RPC_CALL = 'rpc/call'
 RPC_ERROR = 'rpc/error'
@@ -28,15 +28,14 @@ class RpcComponent():
 
     async def call(self, method, args):
         rpc_func = self.get_method(method)
-        result = await typed_async_call(rpc_func, args)
+        result, _ = await typed_async_call(rpc_func, args)
         return result
 
     async def on_rpc(self, conn, method, args, nonce):
         try:
             rpc_func = self.get_method(method)
 
-            result = await typed_async_call(rpc_func, args)
-            result_type = get_return_type(rpc_func)
+            result, result_type = await typed_async_call(rpc_func, args)
 
             await conn.send({
                 'type': RPC_RESULT,

--- a/cowait/tasks/dask/cluster.py
+++ b/cowait/tasks/dask/cluster.py
@@ -45,11 +45,11 @@ class DaskCluster(Task):
     async def after(self, inputs: dict):
         await self.dask.close()
 
-        print('~~ destroying dask cluster')
-        self.scheduler.destroy()
+        print('~~ stopping dask cluster')
+        await self.scheduler.stop()
 
         for worker in self.workers:
-            worker.destroy()
+            await worker.stop()
 
         await super().after(inputs)
 
@@ -90,7 +90,7 @@ class DaskCluster(Task):
             count = len(self.workers)
 
         for worker in self.workers[-count:]:
-            worker.destroy()
+            await worker.stop()
         self.workers = self.workers[:-count]
 
     async def wait_for_nodes(self):

--- a/cowait/tasks/definition.py
+++ b/cowait/tasks/definition.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from marshmallow import Schema, fields, post_load
 from ..utils import uuid
+from .status import WAIT
 
 
 def generate_task_id(name: str) -> str:
@@ -52,6 +53,10 @@ class TaskDefinition(object):
         cpu:       str = '0',
         memory:    str = '0',
         owner:     str = '',
+        status:    str = WAIT,
+        error:     str = None,
+        result:    any = None,
+        log:       str = '',
         created_at: datetime = None,
     ):
         """
@@ -85,6 +90,10 @@ class TaskDefinition(object):
         self.memory = memory
         self.owner = owner
         self.volumes = volumes
+        self.status = status
+        self.error = error
+        self.result = result
+        self.log = log
 
         if created_at is None:
             self.created_at = datetime.now(timezone.utc)
@@ -121,7 +130,7 @@ class TaskDefinitionSchema(Schema):
     cpu = fields.Str(missing='0')
     memory = fields.Str(missing='0')
     owner = fields.Str(missing='')
-    status = fields.Str(allow_none=True)
+    status = fields.Str(missing=WAIT)
     error = fields.Str(allow_none=True)
     result = fields.Raw(allow_none=True)
     log = fields.Str(allow_none=True)

--- a/cowait/tasks/errors.py
+++ b/cowait/tasks/errors.py
@@ -1,5 +1,9 @@
 
 
+class StoppedError(RuntimeError):
+    pass
+
+
 class TaskError(RuntimeError):
     """
     Raised when an error is received from a subtask

--- a/cowait/tasks/remote_task.py
+++ b/cowait/tasks/remote_task.py
@@ -16,9 +16,6 @@ class RemoteTask(TaskDefinition):
         self.cluster = cluster
         self.future = Future()
         self.awaitable = asyncio.wrap_future(self.future)
-        self.status = WAIT
-        self.error = None
-        self.result = None
 
     def __await__(self):
         return self.awaitable.__await__()

--- a/cowait/tasks/spark/cluster.py
+++ b/cowait/tasks/spark/cluster.py
@@ -87,9 +87,9 @@ class SparkCluster(Task):
 
     async def after(self, inputs: dict):
         print('~~ destroying spark cluster')
-        self.master.destroy()
+        await self.master.stop()
         for worker in self.workers:
-            worker.destroy()
+            await worker.stop()
 
         await super().after(inputs)
 
@@ -164,7 +164,7 @@ class SparkCluster(Task):
             count = len(self.workers)
 
         for worker in self.workers[-count:]:
-            worker.destroy()
+            await worker.stop()
         self.workers = self.workers[:-count]
 
     async def wait_for_nodes(self):

--- a/cowait/tasks/task.py
+++ b/cowait/tasks/task.py
@@ -1,6 +1,7 @@
 import sys
 from typing import Any
 from cowait.network import get_local_connstr
+from cowait.types import serialize
 from .definition import TaskDefinition
 from .components import TaskManager, RpcComponent, rpc
 from .parent_task import ParentTask
@@ -130,8 +131,8 @@ class Task(TaskDefinition):
                 **volumes,
             },
             inputs={
-                **inputs,
-                **kwargs,
+                **serialize(inputs),
+                **serialize(kwargs),
             },
             env={
                 **self.env,

--- a/cowait/tasks/test_task_definition.py
+++ b/cowait/tasks/test_task_definition.py
@@ -18,6 +18,10 @@ def test_taskdef_serialization():
         'cpu':        '0',
         'memory':     '0',
         'owner':      'santa',
+        'status':     'wait',
+        'result':     None,
+        'error':      None,
+        'log':        '',
     }
 
     taskdef = TaskDefinition.deserialize(sample)

--- a/cowait/types/simple.py
+++ b/cowait/types/simple.py
@@ -126,7 +126,7 @@ class DateTime(Type):
         return datetime.fromisoformat(value)
 
 
-@TypeAlias(type(None))
+@TypeAlias(type(None), None)
 class Void(Type):
     def validate(self, value, name: str):
         if value is not None:

--- a/cowait/types/utils.py
+++ b/cowait/types/utils.py
@@ -82,11 +82,13 @@ def typed_return(func: callable, result: object) -> object:
     Type checks and serializes a return value using cowait types.
     """
     result_type = get_return_type(func)
+    if isinstance(result_type, Any):
+        result_type = guess_type(result)
 
     # serialize & validate
     data = result_type.serialize(result)
     result_type.validate(data, 'Return')
-    return data
+    return data, result_type
 
 
 async def typed_call(func: callable, args: dict) -> object:

--- a/cowait/utils/stream_capture.py
+++ b/cowait/utils/stream_capture.py
@@ -24,18 +24,26 @@ class StreamCapture(object):
             self.stream.write(data)
 
         if '\n' in data:
-            self.flush()
+            self.flush(auto=True)
 
-    def flush(self):
-        self.capture.flush()
-
+    def flush(self, auto: bool = False):
         if not self.silence:
             self.stream.flush()
 
         if callable(self.callback):
-            self.callback(self.getvalue())
-
-        self.capture = StringIO()
+            value = self.getvalue()
+            if auto:
+                # auto flush happens if \n exists, so we dont need to check for it
+                last_break = value.rfind('\n')
+                self.capture = StringIO(value[last_break+1:])
+                self.callback(value[:last_break+1])
+            else:
+                # non-automated flush should return the full value
+                self.capture = StringIO()
+                self.callback(value)
+        else:
+            # if there is no callback, simply clear the capture buffer
+            self.capture = StringIO()
 
     def getvalue(self):
         data = self.capture.getvalue()

--- a/cowait/utils/stream_capture.py
+++ b/cowait/utils/stream_capture.py
@@ -41,9 +41,6 @@ class StreamCapture(object):
         data = self.capture.getvalue()
         return data
 
-    def __del__(self):
-        del self.capture
-
 
 class StreamCapturing(object):
     def __init__(

--- a/cowait/worker/executor.py
+++ b/cowait/worker/executor.py
@@ -2,7 +2,7 @@ import asyncio
 import traceback
 from cowait.engine import ClusterProvider
 from cowait.tasks import Task, TaskDefinition, TaskError
-from cowait.types import typed_arguments, typed_return, get_return_type, get_parameter_defaults
+from cowait.types import typed_arguments, typed_return, get_parameter_defaults
 from .worker_node import WorkerNode
 from .service import FlowLogger, NopLogger
 from .loader import load_task_class
@@ -82,8 +82,7 @@ async def execute(cluster: ClusterProvider, taskdef: TaskDefinition) -> None:
             await handle_orphans(task)
 
             # prepare & typecheck result
-            result = typed_return(taskfunc, result)
-            result_type = get_return_type(taskfunc)
+            result, result_type = typed_return(taskfunc, result)
 
             # submit result
             await node.parent.send_done(result, result_type.describe())

--- a/cowait/worker/executor.py
+++ b/cowait/worker/executor.py
@@ -110,14 +110,14 @@ async def execute(cluster: ClusterProvider, taskdef: TaskDefinition) -> None:
         await asyncio.sleep(0.5)
 
 
-async def handle_orphans(task: Task, mode: str = 'kill') -> None:
+async def handle_orphans(task: Task, mode: str = 'stop') -> None:
     orphans = filter(lambda child: not child.done, task.subtasks.values())
     for orphan in orphans:
         if mode == 'wait':
             print('~~ waiting for orphaned task', orphan.id)
             await orphan
-        elif mode == 'kill':
-            print('~~ killing orphaned task', orphan.id)
-            orphan.destroy()
+        elif mode == 'stop':
+            print('~~ stopping orphaned task', orphan.id)
+            await orphan.stop()
         else:
             raise RuntimeError(f'Unknown orphan mode {mode}')

--- a/cowait/worker/parent_client.py
+++ b/cowait/worker/parent_client.py
@@ -51,7 +51,6 @@ class ParentClient(Client):
         """ Send status update: Stopped """
         id = self.id if id is None else id
         await self.msg(TASK_STATUS, status=STOP, id=id)
-        await self.msg(TASK_RETURN, result={}, id=id)
 
     async def send_done(self, result: Any, result_type: str = 'any') -> None:
         """


### PR DESCRIPTION
- Agent always runs on port 1339 in Docker
- Agent no longer requires token authentication in Docker
- Improved support for stopping tasks
- Stop orphan tasks instead of using `ClusterProvider.destroy()`
- Fix a bug in `StreamCapture`
- Fix a typo in `Traefik2Router`

resolve #136 