### PR TITLE
Storage

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,6 +25,8 @@ nest-asyncio = "*"
 numpy = "*"
 sty = "*"
 python-dotenv = "*"
+fsspec = "*"
+s3fs = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ffb312cb17258dbe904cb458514b74da72ee62f141e5ec500dc65b8cf5c6ef03"
+            "sha256": "177342b372650d8e847738af5ee28052ddb21daa780971d181de7f83d6d9a120"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -55,6 +55,13 @@
                 "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
             "version": "==19.3.0"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:34ebc56471a75ea28bfd39f1665d58ee13229c75e8cd6c62b2e2abf1f3e75f0f",
+                "sha256:bb3d3e6aa1fb0caac5909421404218fa7fdcdfc5a1b597ec93cb3affb8326d26"
+            ],
+            "version": "==1.17.15"
         },
         "cachetools": {
             "hashes": [
@@ -152,6 +159,22 @@
             "index": "pypi",
             "version": "==4.2.2"
         },
+        "docutils": {
+            "hashes": [
+                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
+                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
+                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
+            ],
+            "version": "==0.15.2"
+        },
+        "fsspec": {
+            "hashes": [
+                "sha256:1f9391c9b6e92a89949f0b0f7154b8b62a01f00b9c2767797d94ffa376dae9ab",
+                "sha256:7075fde6d617cd3a97eac633d230d868121a188a46d16a0dcb484eea0cf2b955"
+            ],
+            "index": "pypi",
+            "version": "==0.7.4"
+        },
         "google-auth": {
             "hashes": [
                 "sha256:5e3f540b7b0b892000d542cea6b818b837c230e9a4db9337bb2973bcae0fc078",
@@ -180,6 +203,13 @@
             ],
             "markers": "python_version < '3.8'",
             "version": "==1.7.0"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
+            ],
+            "version": "==0.10.0"
         },
         "kubernetes": {
             "hashes": [
@@ -439,6 +469,14 @@
             "markers": "python_version >= '3'",
             "version": "==4.6"
         },
+        "s3fs": {
+            "hashes": [
+                "sha256:2ca5de8dc18ad7ad350c0bd01aef0406aa5d0fff78a561f0f710f9d9858abdd0",
+                "sha256:91c1dfb45e5217bd441a7a560946fe865ced6225ff7eb0fb459fe6e601a95ed3"
+            ],
+            "index": "pypi",
+            "version": "==0.4.2"
+        },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
@@ -499,6 +537,7 @@
                 "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
                 "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
             ],
+            "markers": "python_version != '3.4'",
             "version": "==1.25.9"
         },
         "wcwidth": {

--- a/cowait/cli/commands/run.py
+++ b/cowait/cli/commands/run.py
@@ -75,6 +75,7 @@ def run(
             volumes=volumes,
             memory=memory,
             cpu=cpu,
+            storage=context.get('storage', {}),
         )
 
         # print execution info

--- a/cowait/storage/__init__.py
+++ b/cowait/storage/__init__.py
@@ -1,0 +1,23 @@
+# flake8: noqa: F401
+
+from .backends import StorageBackends
+
+from fsspec.implementations.local import LocalFileOpener
+from fsspec.implementations.http import HTTPFile
+from fsspec.implementations.ftp import FTPFile
+
+FileFormats = [LocalFileOpener, HTTPFile, FTPFile]
+
+# HDFS (requires pyarrow)
+try:
+    from fsspec.implementations.hdfs import HDFSFile
+    FileFormats.append(HDFSFile)
+except ImportError:
+    pass
+
+# S3 (requires s3fs)
+try:
+    from s3fs import S3File
+    FileFormats.append(S3File)
+except ImportError:
+    pass

--- a/cowait/storage/backends.py
+++ b/cowait/storage/backends.py
@@ -1,0 +1,42 @@
+import fsspec
+
+
+class StorageBackends(object):
+    cache = {}
+
+    def __init__(self, backends: dict = {}):
+        self.backends = {}
+        if not isinstance(backends, dict):
+            raise TypeError('backends must be a dict')
+        for name, store in backends.items():
+            self.add(name, **store)
+
+    def add(self, name: str, protocol: str, **storage) -> None:
+        fs = fsspec.filesystem(protocol, **storage)
+        self.backends[name] = fs
+
+    def get(self, attr) -> fsspec.AbstractFileSystem:
+        return self.backends.get(attr)
+
+    def __getattr__(self, attr) -> fsspec.AbstractFileSystem:
+        return self.backends.get(attr)
+
+    def __getitem__(self, attr) -> fsspec.AbstractFileSystem:
+        return self.backends.get(attr)
+
+    def open(self, path: str, **kwargs):
+        if len(self.backends) > 1:
+            raise RuntimeError('Cant use open() shorthand with multiple backends')
+        if len(self.backends) == 0:
+            raise RuntimeError('No storage backend defined')
+        fs = next(iter(self.backends.values()))
+        return fs.open(path, **kwargs)
+
+    @staticmethod
+    def from_json(json):
+        if json in StorageBackends.cache:
+            return StorageBackends.cache[json]
+
+        fs = fsspec.AbstractFileSystem.from_json(json)
+        StorageBackends.cache[json] = fs
+        return fs

--- a/cowait/tasks/definition.py
+++ b/cowait/tasks/definition.py
@@ -57,6 +57,7 @@ class TaskDefinition(object):
         error:     str = None,
         result:    any = None,
         log:       str = '',
+        storage:   dict = {},
         created_at: datetime = None,
     ):
         """
@@ -94,6 +95,7 @@ class TaskDefinition(object):
         self.error = error
         self.result = result
         self.log = log
+        self.storage = storage
 
         if created_at is None:
             self.created_at = datetime.now(timezone.utc)
@@ -135,6 +137,7 @@ class TaskDefinitionSchema(Schema):
     result = fields.Raw(allow_none=True)
     log = fields.Str(allow_none=True)
     created_at = fields.DateTime('iso', default=lambda: datetime.now(timezone.utc))
+    storage = fields.Dict(missing={})
     volumes = fields.Mapping(
         keys=fields.Str(),
         values=fields.Mapping(),

--- a/cowait/tasks/test_task_definition.py
+++ b/cowait/tasks/test_task_definition.py
@@ -13,6 +13,7 @@ def test_taskdef_serialization():
         'ports':      {},
         'routes':     {},
         'volumes':    {},
+        'storage':    {},
         'upstream':   None,
         'created_at': '2020-02-02T20:00:02+00:00',
         'cpu':        '0',

--- a/cowait/types/__init__.py
+++ b/cowait/types/__init__.py
@@ -6,6 +6,7 @@ from .list import List
 from .custom import CustomType
 from .simple import Any, String, Int, Float, Bool, DateTime, Void
 from .numpy import NumpyInt, NumpyFloat, NumpyBool, NumpyArray
+from .fs import FileType
 from .mapping import TypeAlias
 from .utils import typed_arguments, typed_return, \
     typed_call, typed_async_call, serialize, deserialize, \

--- a/cowait/types/fs.py
+++ b/cowait/types/fs.py
@@ -1,0 +1,28 @@
+from cowait.storage import StorageBackends, FileFormats
+from .type import Type
+from .mapping import TypeAlias
+
+
+@TypeAlias(*FileFormats)
+class FileType(Type):
+    name: str = 'File'
+
+    def validate(self, value: any, name: str) -> None:
+        if not isinstance(value, dict):
+            raise TypeError(f'Expected {name} to be dict file representation')
+
+        if 'path' not in value:
+            raise TypeError(f'File {name} has no path')
+
+        if 'fs' not in value:
+            raise TypeError(f'File {name} has no path')
+
+    def serialize(self, file) -> dict:
+        return {
+            'path': file.path,
+            'fs': file.fs.to_json(),
+        }
+
+    def deserialize(self, value: dict):
+        fs = StorageBackends.from_json(value['fs'])
+        return fs.open(value['path'])

--- a/cowait/worker/executor.py
+++ b/cowait/worker/executor.py
@@ -2,6 +2,7 @@ import traceback
 from cowait.engine import ClusterProvider
 from cowait.tasks import Task, TaskDefinition, TaskError
 from cowait.types import typed_arguments, typed_return, get_parameter_defaults
+from cowait.storage import StorageBackends
 from .worker_node import WorkerNode
 from .loader import load_task_class
 
@@ -31,6 +32,9 @@ async def execute(cluster: ClusterProvider, taskdef: TaskDefinition) -> None:
                 cluster=cluster,
                 node=node,
             )
+
+            # initialize storage
+            task.storage = StorageBackends(task.storage)
 
             # initialize task
             task.init()

--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,7 @@ setuptools.setup(
         'jupyterlab',
         'dill',
         'python-dotenv',
+        'fsspec',
+        's3fs',
     ],
 )


### PR DESCRIPTION
Experimental implementation of a unified storage solution based on `fsspec`. 

Allows the definition of storage backends in `cowait.yml`.

**Example Code:**
```yml
cowait:
  storage:
    example:
      protocol: s3
      api_key: 123123
```

```python
class MyTask(Task):
    async def run(self):
        f = self.storage.example.open('bucket/hello.csv')
        df = pandas.read_csv(f)
        print(df.show())
```