### PR TITLE
disable builds without a context file, clean up config ambiguities

### DIFF
--- a/bin/cowait
+++ b/bin/cowait
@@ -39,16 +39,11 @@ def cli(ctx):
 @click.argument('name', type=str, required=False)
 @click.option('--image', type=str, required=False, help='image name')
 @click.option('--base', type=str, required=False, help='base image name')
-@click.option('--cluster',
-              default=None,
-              type=str,
-              help='cluster name')
-def new_context(name: str, image: str, base: str, cluster_name: str):
+def new(name: str, image: str, base: str):
     cowait.cli.new_context(
         name=name,
         image=image,
         base=base,
-        cluster_name=cluster_name,
     )
 
 

--- a/cowait/cli/commands/agent.py
+++ b/cowait/cli/commands/agent.py
@@ -5,7 +5,6 @@ from cowait.utils.const import DEFAULT_BASE_IMAGE
 from cowait.utils import uuid
 from ..errors import CliError
 from ..config import CowaitConfig
-from ..context import CowaitContext
 from ..utils import ExitTrap
 from .run import RunLogger
 
@@ -17,9 +16,7 @@ def agent(
 ) -> None:
     logger = RunLogger(quiet=False, raw=False)
     try:
-        context = CowaitContext.open()
-        cluster_name = context.get('cluster', config.default_cluster)
-        cluster = config.get_cluster(cluster_name)
+        cluster = config.get_cluster(config.default_cluster)
 
         if cluster.type == 'api':
             raise CliError('Error: Cant deploy agent using an API cluster')

--- a/cowait/cli/commands/build.py
+++ b/cowait/cli/commands/build.py
@@ -1,15 +1,22 @@
 import os.path
+import docker
 import docker.errors
 import docker.credentials.errors
 from cowait.utils.const import DEFAULT_BASE_IMAGE
-from ..task_image import TaskImage, BuildError, Dockerfile
-from ..context import CowaitContext
+from ..task_image import TaskImage, BuildError
+from ..docker_file import Dockerfile
+from ..context import CowaitContext, CONTEXT_FILE_NAME
 from ..logger import Logger
 
 
 def build(quiet: bool = False, workdir: str = None) -> TaskImage:
     logger = Logger(quiet)
     try:
+        if not CowaitContext.exists():
+            logger.println(f'No {CONTEXT_FILE_NAME} found. '
+                           f'Using default image: {DEFAULT_BASE_IMAGE}')
+            return TaskImage.get(DEFAULT_BASE_IMAGE)
+
         context = CowaitContext.open()
         context.override('workdir', workdir)
 

--- a/cowait/cli/commands/new_context.py
+++ b/cowait/cli/commands/new_context.py
@@ -8,7 +8,6 @@ def new_context(
     name: str,
     image: str,
     base: str,
-    cluster_name: str = None,
 ):
     path = os.getcwd()
 
@@ -31,10 +30,6 @@ def new_context(
         print('Base image:', base)
         context['base'] = base
 
-    # override default cluster
-    if cluster_name is not None:
-        context['cluster'] = cluster_name
-
     context_file = os.path.join(path, CONTEXT_FILE_NAME)
     if os.path.isfile(context_file):
         print('Error: Context file', context_file, 'already exists')
@@ -48,6 +43,7 @@ def new_context(
             },
             stream=cf,
             sort_keys=False,
+            default_flow_style=False,
         )
 
     print('Created new context definition', context_file)

--- a/cowait/cli/commands/run.py
+++ b/cowait/cli/commands/run.py
@@ -32,8 +32,7 @@ def run(
     logger = RunLogger(raw, quiet)
     try:
         context = CowaitContext.open()
-        cluster_name = context.get('cluster', config.default_cluster)
-        cluster = config.get_cluster(cluster_name)
+        cluster = config.get_cluster(config.default_cluster)
 
         # figure out image name
         remote_image = True
@@ -41,7 +40,7 @@ def run(
         if image is None:
             if build:
                 build_cmd(quiet=quiet or raw)
-            image = context.get_image_name()
+            image = context.image
             remote_image = False
 
         volumes = context.get('volumes', {})
@@ -79,7 +78,7 @@ def run(
         )
 
         # print execution info
-        logger.print_info(taskdef, cluster_name)
+        logger.print_info(taskdef, config.default_cluster)
 
         # submit task to cluster
         task = cluster.spawn(taskdef)

--- a/cowait/cli/commands/test.py
+++ b/cowait/cli/commands/test.py
@@ -16,8 +16,7 @@ def test(
     logger = TestLogger()
     try:
         context = CowaitContext.open()
-        cluster_name = context.get('cluster', config.default_cluster)
-        cluster = config.get_cluster(cluster_name)
+        cluster = config.get_cluster(config.default_cluster)
 
         if push:
             run_push()

--- a/cowait/cli/docker_file.py
+++ b/cowait/cli/docker_file.py
@@ -1,0 +1,35 @@
+import docker
+
+# shim that allows passing dockerfiles as a string together with a context path.
+# this removes the need to write temporary files!
+# source: https://github.com/docker/docker-py/issues/2105
+docker.api.build.process_dockerfile = lambda dockerfile, path: ('Dockerfile', dockerfile)
+
+
+class Dockerfile(object):
+    """ Simple tool for creating dockerfiles """
+
+    def __init__(self, base):
+        self.lines = [f'FROM {base}']
+
+    def copy(self, src, dst):
+        self.lines.append(f'COPY {src} {dst}')
+
+    def run(self, cmd):
+        self.lines.append(f'RUN {cmd}')
+
+    def env(self, key: str, value: str):
+        self.lines.append(f'ENV {key}={value}')
+
+    def workdir(self, path):
+        self.lines.append(f'WORKDIR {path}')
+
+    def __str__(self):
+        return '\n'.join(self.lines)
+
+    @staticmethod
+    def read(path):
+        with open(path, 'r') as f:
+            df = Dockerfile('none')
+            df.lines = f.readlines()
+            return df

--- a/cowait/engine/docker.py
+++ b/cowait/engine/docker.py
@@ -65,6 +65,9 @@ class DockerProvider(ClusterProvider):
             self.emit_sync('spawn', task=task)
             return task
 
+        except docker.errors.APIError as e:
+            raise ProviderError(e.explanation)
+
         except requests.exceptions.ConnectionError:
             raise ProviderError('Docker engine unavailable')
 


### PR DESCRIPTION
- Disables building of images without a `cowait.yml` file.
- Resolves configuration ambiguities.

- User-wide configuration lives in `~/.cowait.yml`
- Project settings live in `cowait.yml`. 
- CLI parameters can override both.

resolve #134
resolve #152 
