### PR TITLE
Setter for default_cluster, --cluster argument

### DIFF
--- a/cowait/cli/config.py
+++ b/cowait/cli/config.py
@@ -29,6 +29,10 @@ class CowaitConfig(SettingsDict):
     @property
     def default_cluster(self) -> str:
         return self.get('default_cluster', 'docker', False)
+    
+    @default_cluster.setter
+    def default_cluster(self, value):
+        self.set("default_cluster", value)
 
     def get_cluster(self, cluster_name: str = None):
         if cluster_name is None:


### PR DESCRIPTION
Running tasks on specific clusters failed due to an invalid setting of a private attribute with click.

`cowait run --cluster {cluster} {task}`

generated the following error

```bash
Traceback (most recent call last):
  File "/home/emil/.local/bin/cowait", line 307, in <module>
    cli(obj=config)
  File "/usr/lib/python3/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/emil/.local/bin/cowait", line 109, in run
    ctx.obj.default_cluster = cluster
AttributeError: can't set attribute
```

A setter method solves this issue. 

