### PR TITLE
Apply nest_asyncio patch for all tasks

### DIFF
--- a/cowait/exec.py
+++ b/cowait/exec.py
@@ -2,14 +2,15 @@
 Task worker entry point.
 
 Environment:
-    TASK_CLUSTER (json): JSON-serialized ClusterProvider
-    TASK_DEFINITION (json): JSON-serialized TaskDefinition
+    COWAIT_CLUSTER (json): JSON-serialized ClusterProvider
+    COWAIT_TASK (json): JSON-serialized TaskDefinition
 """
 import os
 import sys
 import json
 import asyncio
 import traceback
+import nest_asyncio
 from cowait.tasks.messages import TASK_FAIL
 from cowait.worker import execute, \
     env_get_cluster_provider, \
@@ -40,6 +41,9 @@ async def main():
         os._exit(1)
 
     os._exit(0)
+
+# apply a patch that allows nested asyncio loops
+nest_asyncio.apply()
 
 # run asyncio loop
 asyncio.run(main())

--- a/cowait/test/test_task.py
+++ b/cowait/test/test_task.py
@@ -1,6 +1,5 @@
 import pytest
 import asyncio
-import nest_asyncio
 from alt_pytest_asyncio.plugin import AltPytestAsyncioPlugin
 from cowait import Task
 
@@ -8,9 +7,6 @@ from cowait import Task
 class PytestTask(Task):
     async def run(self):
         loop = asyncio.get_event_loop()
-
-        # apply a patch that allows nested asyncio loops
-        nest_asyncio.apply(loop)
 
         plugins = [
             AltPytestAsyncioPlugin(loop=loop),


### PR DESCRIPTION
Ideally this PR should resolve all asyncio-related issues appearing in #115 

As of right now:
- Apply `nest_asyncio` patch to all tasks.
- Remove `nest_asyncio` patch from `cowait test` (since its applied everywhere)

Other things to try:
- Rewrite any `async for` loops
- Last resort: Supress `asyncio.CancelledError` from websocket sends.

resolve #175 
