### PR TITLE
Remove logging of environment variables on Task run

### DIFF
--- a/cowait/cli/commands/run.py
+++ b/cowait/cli/commands/run.py
@@ -160,8 +160,6 @@ class RunLogger(Logger):
         self.println('   image:     ', self.json(taskdef.image))
         if len(taskdef.inputs) > 0:
             self.println('   inputs:    ', self.json(taskdef.inputs))
-        if len(taskdef.env) > 0:
-            self.println('   env:       ', self.json(taskdef.env))
         if len(taskdef.volumes) > 0:
             self.println('   volumes:   ', self.json(taskdef.volumes))
         if len(taskdef.storage) > 0:


### PR DESCRIPTION
Avoids logging potentially sensitive information. Should be re-introduced as a debugging feature at some point in the future.

resolve #172 