### PR TITLE
Build CLI Args: Quiet & Image name

### DIFF
--- a/bin/cowait
+++ b/bin/cowait
@@ -240,8 +240,15 @@ def notebook(ctx, cluster, build, image):
               default=None,
               type=str,
               help='task working directory')
-def build(workdir: str):
-    cowait.cli.build(workdir)
+@click.option('-i', '--image',
+              default=None,
+              type=str,
+              help='image name')
+def build(workdir: str, image: str):
+    cowait.cli.build(
+        workdir=workdir, 
+        image_name=image,
+    )
 
 
 @cli.command(help='push a task to the registry')

--- a/bin/cowait
+++ b/bin/cowait
@@ -236,6 +236,10 @@ def notebook(ctx, cluster, build, image):
 
 
 @cli.command(help='build a task')
+@click.option('-q', '--quiet',
+              type=bool, is_flag=True,
+              help='no output except result',
+              default=False)
 @click.option('-w', '--workdir',
               default=None,
               type=str,
@@ -244,8 +248,9 @@ def notebook(ctx, cluster, build, image):
               default=None,
               type=str,
               help='image name')
-def build(workdir: str, image: str):
+def build(quiet: bool, workdir: str, image: str):
     cowait.cli.build(
+        quiet=quiet,
         workdir=workdir, 
         image_name=image,
     )

--- a/cowait/cli/commands/build.py
+++ b/cowait/cli/commands/build.py
@@ -56,6 +56,7 @@ def build(quiet: bool = False, workdir: str = None, image_name: str = None) -> T
         image.build(
             base=base_image,
             requirements=requirements,
+            quiet=quiet,
         )
 
         return image

--- a/cowait/cli/commands/build.py
+++ b/cowait/cli/commands/build.py
@@ -9,7 +9,7 @@ from ..context import CowaitContext, CONTEXT_FILE_NAME
 from ..logger import Logger
 
 
-def build(quiet: bool = False, workdir: str = None) -> TaskImage:
+def build(quiet: bool = False, workdir: str = None, image_name: str = None) -> TaskImage:
     logger = Logger(quiet)
     try:
         if not CowaitContext.exists():
@@ -19,6 +19,9 @@ def build(quiet: bool = False, workdir: str = None) -> TaskImage:
 
         context = CowaitContext.open()
         context.override('workdir', workdir)
+
+        if image_name is not None:
+            context.override('image', image_name)
 
         image = TaskImage.open(context)
         logger.header('BUILD')

--- a/cowait/cli/task_image.py
+++ b/cowait/cli/task_image.py
@@ -20,7 +20,7 @@ class TaskImage(object):
     def name(self):
         return self.context.image
 
-    def build(self, base: str, requirements: str = None) -> None:
+    def build(self, base: str, requirements: str = None, quiet: bool = False) -> None:
         """ Build task image """
 
         # create temporary dockerfile
@@ -43,6 +43,7 @@ class TaskImage(object):
             dockerfile=str(df),
             path=self.context.root_path,
             tag=f'{self.name}:latest',
+            quiet=quiet,
         )
 
     def push(self):
@@ -79,19 +80,21 @@ class TaskImage(object):
         return client.images.get(name_or_id)
 
     @staticmethod
-    def build_image(**kwargs):
+    def build_image(quiet: bool, **kwargs):
         logs = client.api.build(decode=True, rm=True, **kwargs)
 
         image_hash = None
         for log in logs:
             if 'stream' in log:
-                print(log['stream'], end='', flush=True)
+                if not quiet:
+                    print(log['stream'], end='', flush=True)
             elif 'aux' in log and 'ID' in log['aux']:
                 image_hash = log['aux']['ID']
             elif 'errorDetail' in log:
                 raise BuildError(log['errorDetail']['message'])
             else:
-                print(log)
+                if not quiet:
+                    print(log)
 
         if image_hash is not None:
             return TaskImage.get(image_hash)


### PR DESCRIPTION
Adds two new arguments to `cowait build`:
- `--image <image name>`: Overrides the tag of the built image
- `--quiet`: Disables stdout logging

resolve #168 