### PR TITLE
Improved task operators

### DIFF
--- a/cowait/__init__.py
+++ b/cowait/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa: F401
 
-from .tasks import Task, task, rpc, join, sleep
+from .tasks import Task, task, rpc, join, wait, sleep

--- a/cowait/__init__.py
+++ b/cowait/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa: F401
 
-from .tasks import Task, task, rpc, join, gather, sleep
+from .tasks import Task, task, rpc, join, sleep

--- a/cowait/tasks/__init__.py
+++ b/cowait/tasks/__init__.py
@@ -11,6 +11,6 @@ from .remote_task import RemoteTask
 from .definition import TaskDefinition
 from .instance import TaskInstance
 from .decorator import task
-from .ops import join
+from .ops import join, wait
 
 from .components.rpc import rpc

--- a/cowait/tasks/__init__.py
+++ b/cowait/tasks/__init__.py
@@ -11,6 +11,6 @@ from .remote_task import RemoteTask
 from .definition import TaskDefinition
 from .instance import TaskInstance
 from .decorator import task
-from .ops import join, gather
+from .ops import join
 
 from .components.rpc import rpc

--- a/cowait/tasks/ops.py
+++ b/cowait/tasks/ops.py
@@ -1,13 +1,6 @@
 import asyncio
 
 
-async def join(tasks):
+async def join(tasks: list) -> list:
+    """ Waits for a list of tasks to complete, returning a list containing their results. """
     return await asyncio.gather(*tasks)
-    done, pending = await asyncio.wait(tasks)
-    return list(done)
-
-
-async def gather(*tasks):
-    return await asyncio.gather(*tasks)
-    done, pending = await asyncio.wait(tasks)
-    return list(done)

--- a/cowait/tasks/ops.py
+++ b/cowait/tasks/ops.py
@@ -4,3 +4,8 @@ import asyncio
 async def join(tasks: list) -> list:
     """ Waits for a list of tasks to complete, returning a list containing their results. """
     return await asyncio.gather(*tasks)
+
+
+async def wait(tasks: list, ignore_errors: bool = False) -> None:
+    """ Waits for a list of tasks to complete. Returns nothing. """
+    await asyncio.gather(*tasks, return_exceptions=ignore_errors)


### PR DESCRIPTION
- Removed depracted `gather` function, since it's no different from `join`.
- Added a `wait` function that waits for a list of tasks to complete without returning their results. Includes an option to ignore exceptions.