### PR TITLE
Agent production deployment

### DIFF
--- a/cloud/Dockerfile
+++ b/cloud/Dockerfile
@@ -1,12 +1,17 @@
-FROM node:latest
+FROM node:12.2.0-alpine as build
 RUN mkdir /app
 WORKDIR /app
-EXPOSE 1339
+ENV PATH /app/node_modules/.bin:$PATH
+COPY package.json /app/package.json
+RUN npm install --silent
+RUN npm install react-scripts@3.0.1 -g --silent
+COPY . /app
+RUN npm run build
 
-COPY ./package.json .
-RUN npm install
-
-COPY ./public /app/public
-COPY ./src /app/src
-
-CMD ["npm", "start"]
+# production environment
+FROM nginx:1.16.0-alpine
+COPY --from=build /app/build /usr/share/nginx/html
+RUN rm /etc/nginx/conf.d/default.conf
+COPY nginx/nginx.conf /etc/nginx/conf.d
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Picked from @emilwareus PR

Creates a proper multistage build of the agent, using nginx to serve the resulting static files.

Might be a bit early for this honestly 😄 

Actually, cowait itself doesn't really use a docker image for the dashboard, its normally hosted by the internal web server. Not sure if an image should be provided for stand-alone deployments, or if it could be removed.