### PR TITLE
Kill tasks by name/search

### DIFF
--- a/bin/cowait
+++ b/bin/cowait
@@ -212,6 +212,19 @@ def kill(ctx, cluster: str, task: str):
     cowait.cli.kill(ctx.obj, task)
 
 
+@cli.command(help='kill all tasks that matches with an "in" statement')
+@click.option('-c', '--cluster',
+              default=None,
+              type=str,
+              help='cluster name')
+@click.argument('partial_task_id', type=str)
+@click.pass_context
+def kill_name_search(ctx, cluster: str, partial_task_id: str):
+    if cluster is not None:
+        ctx.obj.default_cluster = cluster
+    cowait.cli.kill_name_search(ctx.obj, partial_task_id)
+
+
 @cli.command(help='deploy cowait agent')
 @click.option('-c', '--cluster',
               default=None,

--- a/bin/cowait
+++ b/bin/cowait
@@ -199,7 +199,7 @@ def ps(ctx, cluster: str):
     cowait.cli.list_tasks(ctx.obj)
 
 
-@cli.command(help='kill task')
+@cli.command(help='kill tasks by id')
 @click.option('-c', '--cluster',
               default=None,
               type=str,
@@ -210,19 +210,6 @@ def kill(ctx, cluster: str, task: str):
     if cluster is not None:
         ctx.obj.default_cluster = cluster
     cowait.cli.kill(ctx.obj, task)
-
-
-@cli.command(help='kill all tasks that matches with an "in" statement')
-@click.option('-c', '--cluster',
-              default=None,
-              type=str,
-              help='cluster name')
-@click.argument('partial_task_id', type=str)
-@click.pass_context
-def kill_name_search(ctx, cluster: str, partial_task_id: str):
-    if cluster is not None:
-        ctx.obj.default_cluster = cluster
-    cowait.cli.kill_name_search(ctx.obj, partial_task_id)
 
 
 @cli.command(help='deploy cowait agent')

--- a/cowait/cli/commands/misc.py
+++ b/cowait/cli/commands/misc.py
@@ -29,3 +29,18 @@ def kill(config: CowaitConfig, task_id: str):
 
     except ProviderError as e:
         print('Provider error:', str(e))
+
+
+def kill_name_search(config: CowaitConfig, partial_task_id: str):
+    """Kills all tasks that somewhat matches partial_task_id     
+    """
+    try:
+        cluster = config.get_cluster()
+        tasks = cluster.list_all()
+        for task in tasks:
+            if partial_task_id in str(task):
+                cluster.destroy(str(task))
+                print('Killed ', str(task))
+
+    except ProviderError as e:
+        print('Provider error:', str(e))

--- a/cowait/cli/commands/misc.py
+++ b/cowait/cli/commands/misc.py
@@ -22,25 +22,15 @@ def list_tasks(config: CowaitConfig) -> None:
         print('Provider error:', str(e))
 
 
-def kill(config: CowaitConfig, task_id: str):
-    try:
-        cluster = config.get_cluster()
-        cluster.destroy(task_id)
-
-    except ProviderError as e:
-        print('Provider error:', str(e))
-
-
-def kill_name_search(config: CowaitConfig, partial_task_id: str):
-    """Kills all tasks that somewhat matches partial_task_id     
-    """
+def kill(config: CowaitConfig, partial_task_id: str):
+    """ Kills all tasks that somewhat matches partial_task_id """
     try:
         cluster = config.get_cluster()
         tasks = cluster.list_all()
         for task in tasks:
             if partial_task_id in str(task):
                 cluster.destroy(str(task))
-                print('Killed ', str(task))
+                print('killed ', str(task))
 
     except ProviderError as e:
         print('Provider error:', str(e))


### PR DESCRIPTION
Picked from @emilwareus PR

Perhaps this should be the default behaviour of `cowait kill` ?