### PR TITLE
Add support for Docker build args

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/cowait.svg)](https://pypi.org/project/cowait/)
 [![](https://img.shields.io/static/v1?label=docs&message=gitbook&color=blue)](http://docs.cowait.io/)
 [![Website shields.io](https://img.shields.io/website-up-down-green-red/http/shields.io.svg)](http://cowait.io/)
+[![](https://img.shields.io/badge/chat-slack-blueviolet)](https://slack.cowait.io)
 
 Cowait is a framework for creating containerized distributed applications with asynchronous Python. Containerized functions, called *Tasks*, can run locally in Docker or on remote Kubernetes clusters. The intention is to build a novel type of workflow engine that offers maximum flexibility while also requiring minimal setup and configuration. Because of the loose definition of what a Task could be, and the integration with Docker & Kubernetes, Cowait can be used to easily build many types of distributed applications.
 
@@ -13,6 +14,12 @@ Check out the documentation at https://docs.cowait.io/
 ## Notice
 
 Cowait is still in fairly early development. We invite you to try it out and gladly accept your feedback and contributions, but please be aware that breaking API changes may be introduced.
+
+## Community
+
+Join the Cowait development Slack channel! 
+
+Get your invite at https://slack.cowait.io
 
 ## Getting Started
 

--- a/cowait/cli/app/image.py
+++ b/cowait/cli/app/image.py
@@ -1,5 +1,6 @@
 import click
 import cowait.cli.commands
+from .utils import option_dict
 
 
 @click.command(help='build a task')
@@ -15,13 +16,18 @@ import cowait.cli.commands
               default=None,
               type=str,
               help='image name')
+@click.option('-a', '--arg',
+              type=(str, str),
+              multiple=True,
+              help='docker build argument')
 @click.pass_context
-def build(ctx, quiet: bool, workdir: str, image: str):
+def build(ctx, quiet: bool, workdir: str, image: str, arg: dict):
     cowait.cli.build(
         ctx.obj,
         quiet=quiet,
         workdir=workdir,
         image_name=image,
+        buildargs=option_dict(arg),
     )
 
 

--- a/cowait/cli/commands/build.py
+++ b/cowait/cli/commands/build.py
@@ -12,9 +12,10 @@ from ..logger import Logger
 
 def build(
     config: Config, *,
-    quiet: bool = False,
-    workdir: str = None,
-    image_name: str = None,
+    image_name: str = None, 
+    workdir: str = None, 
+    buildargs: dict = {},
+    quiet: bool = False, 
 ) -> TaskImage:
     logger = Logger(quiet)
     try:
@@ -34,6 +35,8 @@ def build(
         logger.println('Image:', image.name)
         logger.println('Context Root:', context.root_path)
         logger.println('Workdir:', context.workdir)
+        for arg, val in buildargs.items():
+            logger.println(f'Argument: {arg}={val}')
 
         # find task-specific requirements.txt
         # if it exists, it will be copied to the container, and installed
@@ -54,6 +57,7 @@ def build(
                 path=os.path.dirname(dockerfile),
                 dockerfile=str(basedf),
                 quiet=quiet,
+                buildargs=buildargs,
             )
             if base is None:
                 raise RuntimeError('Failed to build base image')
@@ -64,6 +68,7 @@ def build(
             base=base_image,
             requirements=requirements,
             quiet=quiet,
+            buildargs=buildargs,
         )
 
         return image

--- a/cowait/cli/commands/build.py
+++ b/cowait/cli/commands/build.py
@@ -53,6 +53,7 @@ def build(
             base = TaskImage.build_image(
                 path=os.path.dirname(dockerfile),
                 dockerfile=str(basedf),
+                quiet=quiet,
             )
             if base is None:
                 raise RuntimeError('Failed to build base image')

--- a/cowait/cli/task_image.py
+++ b/cowait/cli/task_image.py
@@ -20,7 +20,7 @@ class TaskImage(object):
     def name(self):
         return self.context.image
 
-    def build(self, base: str, requirements: str = None, quiet: bool = False) -> None:
+    def build(self, base: str, requirements: str = None, buildargs: dict = {}, quiet: bool = False) -> None:
         """ Build task image """
 
         # create temporary dockerfile
@@ -43,6 +43,7 @@ class TaskImage(object):
             dockerfile=str(df),
             path=self.context.root_path,
             tag=f'{self.name}:latest',
+            buildargs=buildargs,
             quiet=quiet,
         )
 


### PR DESCRIPTION
Adds support for passing build args to `cowait build` using `--arg` or `-a`.

Example:

```Dockerfile
# Dockerfile
FROM cowait/task
ARG SOME_VAR
RUN echo "some_var=$SOME_VAR"
```

```bash
$ cowait build --arg SOME_VAR 123
```