### PR TITLE
Remove default pull secret for kubernetes

### DIFF
--- a/cowait/engine/kubernetes/kubernetes.py
+++ b/cowait/engine/kubernetes/kubernetes.py
@@ -274,7 +274,7 @@ class KubernetesProvider(ClusterProvider):
         ]
 
     def get_pull_secrets(self):
-        secrets = self.args.get('pull_secrets', ['docker'])
+        secrets = self.args.get('pull_secrets', [])
         return [client.V1LocalObjectReference(name=s) for s in secrets]
 
     def find_agent(self):


### PR DESCRIPTION
Pull secrets specified in the podspec seem to override secrets attached to the service account. This means that you need to explicitly set an empty list of pull secrets to use SA secrets.

It also doesn't make sense for cowait to decide on what to name the user's pull secret.