### PR TITLE
v0.4.5

### DIFF
--- a/cowait/cli/commands/notebook.py
+++ b/cowait/cli/commands/notebook.py
@@ -2,9 +2,10 @@ from .run import run as run_cmd
 
 
 def notebook(config, build: bool, image: str = None, cluster_name: str = None) -> None:
-    task = 'cowait.notebook'
-    if image is not None:
-        task = f'{image}/{task}'
+    if image is None:
+        image = 'cowait/notebook'
+
+    task = f'{image}/cowait.notebook'
     return run_cmd(
         config=config,
         task=task,

--- a/cowait/cli/commands/run.py
+++ b/cowait/cli/commands/run.py
@@ -42,7 +42,7 @@ def run(
         image, task = parse_task_image_name(task, None)
         if image is None:
             if build:
-                build_cmd(quiet=quiet or raw)
+                build_cmd(config, quiet=quiet or raw)
             image = context.image
             remote_image = False
 
@@ -84,7 +84,7 @@ def run(
         )
 
         # print execution info
-        logger.print_info(taskdef, config.default_cluster)
+        logger.print_info(taskdef, cluster)
 
         # submit task to cluster
         task = cluster.spawn(taskdef)
@@ -154,12 +154,12 @@ class RunLogger(Logger):
             return
         super().header(title)
 
-    def print_info(self, taskdef, cluster_name):
+    def print_info(self, taskdef, cluster):
         self.id = taskdef.id
 
         self.header('task')
         self.println('   task:      ', self.json(taskdef.id))
-        self.println('   cluster:   ', self.json(cluster_name))
+        self.println('   cluster:   ', self.json(cluster.type), self.json(cluster.args))
         if taskdef.upstream:
             self.println('   upstream:  ', self.json(taskdef.upstream))
         self.println('   image:     ', self.json(taskdef.image))

--- a/cowait/cli/commands/run.py
+++ b/cowait/cli/commands/run.py
@@ -1,6 +1,7 @@
 import sys
 import json
 import getpass
+import docker.errors
 from cowait.tasks import TaskDefinition
 from cowait.engine.errors import TaskCreationError, ProviderError
 from cowait.utils import parse_task_image_name
@@ -9,6 +10,7 @@ from ..config import Config
 from ..context import Context
 from ..utils import ExitTrap
 from ..logger import Logger
+from ..task_image import TaskImage
 from .build import build as build_cmd
 from sty import fg, rs
 
@@ -49,6 +51,9 @@ def run(
         volumes = context.get('volumes', {})
         if not isinstance(volumes, dict):
             raise TaskCreationError('Invalid volume configuration')
+
+        # if we are using the image of the current context, automatically mount the working directory
+        # todo: add an option to disable this
         if not remote_image:
             volumes['/var/task'] = {
                 'bind': {
@@ -86,6 +91,10 @@ def run(
         # print execution info
         logger.print_info(taskdef, cluster)
 
+        # when running in docker, attempt to pull images if they dont exist locally
+        if cluster.type == "docker":
+            TaskImage.pull(image, tag='latest')
+
         # submit task to cluster
         task = cluster.spawn(taskdef)
 
@@ -107,8 +116,10 @@ def run(
 
         logger.header()
 
+    except docker.errors.NotFound as e:
+        logger.print_exception(f'Docker Error: {e.explanation}')
+
     except ProviderError as e:
-        print('Provider error:', str(e))
         logger.print_exception(f'Provider Error: {e}')
 
     except TaskCreationError as e:

--- a/cowait/engine/kubernetes/kubernetes.py
+++ b/cowait/engine/kubernetes/kubernetes.py
@@ -274,7 +274,7 @@ class KubernetesProvider(ClusterProvider):
         ]
 
     def get_pull_secrets(self):
-        secrets = self.args.get('pull_secrets', ['docker'])
+        secrets = self.args.get('pull_secrets', [])
         return [client.V1LocalObjectReference(name=s) for s in secrets]
 
     def find_agent(self):

--- a/cowait/notebook/task.py
+++ b/cowait/notebook/task.py
@@ -4,7 +4,7 @@ from cowait.engine import env_pack, \
     ENV_TASK_CLUSTER, ENV_TASK_DEFINITION, ENV_GZIP_ENABLED
 from .kernel import ENV_KERNEL_TOKEN
 
-TOKEN_PATTERN = re.compile('\\/\\?token\\=([a-z0-9]+)')
+TOKEN_PATTERN = re.compile('\\?token\\=([a-z0-9]+)')
 
 
 class NotebookTask(ShellTask):
@@ -35,9 +35,12 @@ class NotebookTask(ShellTask):
             print('Warning: No route set')
 
     def filter_stdout(self, line):
-        return False
+        return self.filter_jupyter_token(line)
 
     def filter_stderr(self, line):
+        return self.filter_jupyter_token(line)
+
+    def filter_jupyter_token(self, line):
         if self.jupyter_token is None:
             match = re.search(TOKEN_PATTERN, line)
             if match is not None:

--- a/cowait/version.py
+++ b/cowait/version.py
@@ -1,2 +1,2 @@
-version="0.4.4"
+version="0.4.5"
 

--- a/cowait/worker/loader.py
+++ b/cowait/worker/loader.py
@@ -48,5 +48,11 @@ def load_task_class(task_name: str) -> TypeVar:
         _, Class = classes[0]
         return Class
 
-    except ModuleNotFoundError:
-        raise TaskNotFoundError(f'Task module {task_name} not found')
+    except ModuleNotFoundError as e:
+        # if its not the module we were trying to import, the error
+        # originates from the task code
+        if e.name != task_name:
+            raise e
+
+        raise TaskNotFoundError(f'Task module {task_name} not found') from None
+

--- a/images/docker-compose.yml
+++ b/images/docker-compose.yml
@@ -3,3 +3,8 @@ services:
   spark:
     build: './spark'
     image: 'cowait/spark'
+
+  notebook:
+    build: './notebook'
+    image: 'cowait/notebook'
+

--- a/images/notebook/Dockerfile
+++ b/images/notebook/Dockerfile
@@ -1,0 +1,5 @@
+FROM cowait/task
+
+ADD requirements.txt /tmp/notebook-requirements.txt
+RUN pip install -r /tmp/notebook-requirements.txt
+

--- a/images/notebook/requirements.txt
+++ b/images/notebook/requirements.txt
@@ -1,0 +1,4 @@
+jupyterlab
+dill
+papermill
+

--- a/images/spark/Dockerfile
+++ b/images/spark/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y wget default-jre-headless
 ENV JAVA_HOME=/usr/lib/jvm/default-java
 
 # install spark
-ENV SPARK_VERSION=3.0.0
+ENV SPARK_VERSION=3.0.1
 ENV HADOOP_VERSION=3.2
 ENV PY4J_VERSION=0.10.9
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cowait"
-version = "0.4.4"
+version = "0.4.5"
 description = ""
 authors = ["Backtick Technologies <johan@backtick.se>"]
 license = "Apache License v2.0"


### PR DESCRIPTION
**Changes in v0.4.5**
- Removed default pull secret for kubernetes #224
- Improved logging of target cluster in `cowait run`
- Fixed a bug in the `--build` option of `cowait run`
- Better propagation of import/parse erors when running tasks #225
- Updated to Spark v3.0.1 / Hadoop 3.2 in `cowait/spark`
- Created a separate image for Cowait Notebooks, bundling Jupyter #229 
- Automatically pull missing images when using DockerProvider #231