### PR TITLE
Task Affinity setting

### DIFF
--- a/cowait/cli/app/task.py
+++ b/cowait/cli/app/task.py
@@ -67,13 +67,17 @@ from .utils import parse_input_list
               type=bool, is_flag=True,
               help='no output except result',
               default=False)
+@click.option('-a', '--affinity',
+              help='task affinity (stack/spread)',
+              type=str,
+              default=None)
 @click.pass_context
 def run(
     ctx, task: str, cluster: str, name: str,
     input, env, port, route,
     upstream: str, build: bool, detach: bool,
     cpu: str, cpu_limit: str, memory: str, memory_limit: str,
-    file: str, raw: bool, quiet: bool
+    file: str, raw: bool, quiet: bool, affinity: str
 ):
     file_inputs = {}
     if file is not None:
@@ -106,6 +110,7 @@ def run(
         cpu_limit=cpu_limit,
         memory=memory,
         memory_limit=memory_limit,
+        affinity=affinity,
         cluster_name=cluster,
     )
 

--- a/cowait/cli/commands/run.py
+++ b/cowait/cli/commands/run.py
@@ -32,6 +32,7 @@ def run(
     memory_limit: str = None,
     raw: bool = False,
     quiet: bool = False,
+    affinity: str = None,
     cluster_name: str = None,
 ):
     logger = RunLogger(raw, quiet)
@@ -85,6 +86,7 @@ def run(
             cpu_limit=context.override('cpu_limit', cpu_limit),
             memory=context.override('memory', memory),
             memory_limit=context.override('memory_limit', memory_limit),
+            affinity=context.override('affinity', affinity),
             storage=context.get('storage', {}),
         )
 

--- a/cowait/engine/kubernetes/affinity.py
+++ b/cowait/engine/kubernetes/affinity.py
@@ -1,0 +1,132 @@
+from kubernetes import client
+from cowait.engine.const import LABEL_TASK_ID
+
+
+affinity_schema = {
+    'title': 'TaskAffinity',
+    'type': 'object',
+
+    'properties': {
+        'mode': {
+            'type': 'string',
+            'enum': ['stack', 'spread'],
+        },
+        'required': {
+            'type': 'bool',
+        },
+        'weight': {
+            'type': 'number',
+            'minimum': 0,
+            'maximum': 100,
+        },
+        'label': {
+            'type': 'string',
+        },
+        'namespaces': {
+            'type': 'array',
+            'items': {
+                'type': 'string',
+            },
+        },
+        'selectors': {
+            'type': 'array',
+            'items': {
+                'type': 'object',
+                'properties': {
+                    'key': {
+                        'type': 'string',
+                    },
+                    'operator': {
+                        'type': 'string',
+                        'enum': ['In', 'NotIn', 'Exists', 'DoesNotExist'],
+                    },
+                    'values': {
+                        'type': 'array',
+                        'items': {'type': 'string'},
+                    },
+                },
+                'required': ['key', 'operator'],
+            },
+        },
+    },
+    'required': ['mode'],
+}
+
+
+def parse_affinity_item(affinity):
+    return {
+        'mode': affinity.get('mode', 'stack'),
+        'required': affinity.get('required', False),
+        'label': affinity.get('label', 'kubernetes.io/hostname'),
+        'weight': affinity.get('weight', 1),
+        'namespaces': affinity.get('namespaces', None),
+        'selectors': affinity.get('selectors', [
+            {'key': LABEL_TASK_ID, 'operator': 'Exists'},
+        ]),
+    }
+
+
+def create_affinity_selector(selector):
+    return client.V1LabelSelectorRequirement(
+        key=selector.get('key'),
+        operator=selector.get('operator'),
+        values=selector.get('values', []),
+    )
+
+
+def create_affinity_term(item):
+    return client.V1WeightedPodAffinityTerm(
+        weight=item['weight'],
+        pod_affinity_term=client.V1PodAffinityTerm(
+            topology_key=item['label'],
+            namespaces=item['namespaces'],
+            label_selector=client.V1LabelSelector(
+                match_expressions=[create_affinity_selector(s) for s in item['selectors']],
+            ),
+        )
+    )
+
+
+def create_affinity(affinity):
+    affinities = []
+    if affinity is None:
+        return None
+    elif isinstance(affinity, str):
+        affinities = [{'mode': affinity}]
+    elif isinstance(affinity, dict):
+        affinities = [affinity]
+    elif isinstance(affinity, list):
+        pass
+    else:
+        raise ValueError('Illegal affinity definition')
+
+    # fill with defaults
+    affinities = [parse_affinity_item(item) for item in affinities]
+
+    # sort into required/preferred, affinity/anti-affinity
+    stack_req, stack_pref = [], []
+    spread_req, spread_pref = [], []
+    for item in affinities:
+        term = create_affinity_term(item)
+        if item['mode'] == 'stack':
+            if item['required']:
+                stack_req.append(term)
+            else:
+                stack_pref.append(term)
+        elif item['mode'] == 'spread':
+            if item['required']:
+                spread_req.append(term)
+            else:
+                spread_pref.append(term)
+
+    return client.V1Affinity(
+        pod_affinity=client.V1PodAffinity(
+            required_during_scheduling_ignored_during_execution=stack_req,
+            preferred_during_scheduling_ignored_during_execution=stack_pref,
+        ) if len(stack_req) + len(stack_pref) > 0 else None, 
+        pod_anti_affinity=client.V1PodAntiAffinity(
+            required_during_scheduling_ignored_during_execution=spread_req,
+            preferred_during_scheduling_ignored_during_execution=spread_pref,
+        ) if len(spread_req) + len(spread_pref) > 0 else None,
+    )
+

--- a/cowait/engine/kubernetes/kubernetes.py
+++ b/cowait/engine/kubernetes/kubernetes.py
@@ -11,7 +11,8 @@ from cowait.engine.errors import ProviderError, TaskCreationError
 from cowait.engine.routers import create_router
 from .task import KubernetesTask
 from .volumes import create_volumes
-from .utils import create_ports, create_affinity
+from .utils import create_ports
+from .affinity import create_affinity
 
 DEFAULT_NAMESPACE = 'default'
 DEFAULT_SERVICE_ACCOUNT = 'default'

--- a/cowait/engine/kubernetes/kubernetes.py
+++ b/cowait/engine/kubernetes/kubernetes.py
@@ -11,7 +11,7 @@ from cowait.engine.errors import ProviderError, TaskCreationError
 from cowait.engine.routers import create_router
 from .task import KubernetesTask
 from .volumes import create_volumes
-from .utils import create_ports
+from .utils import create_ports, create_affinity
 
 DEFAULT_NAMESPACE = 'default'
 DEFAULT_SERVICE_ACCOUNT = 'default'
@@ -97,6 +97,7 @@ class KubernetesProvider(ClusterProvider):
 
                         containers=[container],
                         service_account_name=self.service_account,
+                        affinity=create_affinity(taskdef.affinity),
                     ),
                 ),
             )

--- a/cowait/engine/kubernetes/utils.py
+++ b/cowait/engine/kubernetes/utils.py
@@ -25,32 +25,3 @@ def convert_port(port, host_port: str = None):
         'host_port': int(host_port),
     }
 
-
-def create_affinity(affinity: str):
-    if affinity not in [None, 'stack', 'spread']:
-        raise ValueError(f'Unknown affinity mode `{affinity}`')
-
-    affinity_term = client.V1WeightedPodAffinityTerm(
-        weight=100,
-        pod_affinity_term=client.V1PodAffinityTerm(
-            topology_key='kubernetes.io/hostname',
-            label_selector=client.V1LabelSelector(
-                match_expressions=[
-                    client.V1LabelSelectorRequirement(
-                        key=LABEL_TASK_ID,
-                        operator='Exists',
-                    ),
-                ]
-            )
-        )
-    )
-    return client.V1Affinity(
-        pod_affinity=client.V1PodAntiAffinity(
-            preferred_during_scheduling_ignored_during_execution=[affinity_term]
-        ) if affinity == 'stack' else None,
-
-        pod_anti_affinity=client.V1PodAntiAffinity(
-            preferred_during_scheduling_ignored_during_execution=[affinity_term]
-        ) if affinity == 'spread' else None,
-    )
-

--- a/cowait/engine/kubernetes/utils.py
+++ b/cowait/engine/kubernetes/utils.py
@@ -1,4 +1,5 @@
 from kubernetes import client
+from cowait.engine.const import LABEL_TASK_ID
 
 
 def create_ports(ports: dict) -> list:
@@ -23,3 +24,33 @@ def convert_port(port, host_port: str = None):
         'container_port': int(port),
         'host_port': int(host_port),
     }
+
+
+def create_affinity(affinity: str):
+    if affinity not in [None, 'stack', 'spread']:
+        raise ValueError(f'Unknown affinity mode `{affinity}`')
+
+    affinity_term = client.V1WeightedPodAffinityTerm(
+        weight=100,
+        pod_affinity_term=client.V1PodAffinityTerm(
+            topology_key='kubernetes.io/hostname',
+            label_selector=client.V1LabelSelector(
+                match_expressions=[
+                    client.V1LabelSelectorRequirement(
+                        key=LABEL_TASK_ID,
+                        operator='Exists',
+                    ),
+                ]
+            )
+        )
+    )
+    return client.V1Affinity(
+        pod_affinity=client.V1PodAntiAffinity(
+            preferred_during_scheduling_ignored_during_execution=[affinity_term]
+        ) if affinity == 'stack' else None,
+
+        pod_anti_affinity=client.V1PodAntiAffinity(
+            preferred_during_scheduling_ignored_during_execution=[affinity_term]
+        ) if affinity == 'spread' else None,
+    )
+

--- a/cowait/tasks/definition.py
+++ b/cowait/tasks/definition.py
@@ -56,6 +56,7 @@ class TaskDefinition(object):
         cpu_limit:    str = None,
         memory:       str = None,
         memory_limit: str = None,
+        affinity:     str = None,
         owner:        str = '',
         created_at:   datetime = None,
     ):
@@ -75,6 +76,7 @@ class TaskDefinition(object):
             cpu_limit (str): CPU limit
             memory (str): Memory request
             memory_limit (str): Memory limit
+            affinity (str): Affinity Mode (None/stack/spread)
             owner (str): Owner name
             created_at (DateTime): Creation date
         """
@@ -95,6 +97,7 @@ class TaskDefinition(object):
         self.owner = owner
         self.volumes = volumes
         self.storage = storage
+        self.affinity = affinity
 
         if created_at is None:
             self.created_at = datetime.now(timezone.utc)
@@ -132,6 +135,7 @@ class TaskDefinitionSchema(Schema):
     cpu_limit = fields.Str(allow_none=True)
     memory = fields.Str(allow_none=True)
     memory_limit = fields.Str(allow_none=True)
+    affinity = fields.Str(allow_none=True)
     owner = fields.Str(missing='')
     created_at = fields.DateTime('iso', default=lambda: datetime.now(timezone.utc))
     storage = fields.Dict(missing={})

--- a/cowait/tasks/definition.py
+++ b/cowait/tasks/definition.py
@@ -135,7 +135,7 @@ class TaskDefinitionSchema(Schema):
     cpu_limit = fields.Str(allow_none=True)
     memory = fields.Str(allow_none=True)
     memory_limit = fields.Str(allow_none=True)
-    affinity = fields.Str(allow_none=True)
+    affinity = fields.Raw(allow_none=True)
     owner = fields.Str(missing='')
     created_at = fields.DateTime('iso', default=lambda: datetime.now(timezone.utc))
     storage = fields.Dict(missing={})

--- a/cowait/tasks/task.py
+++ b/cowait/tasks/task.py
@@ -111,6 +111,7 @@ class Task(object):
         cpu_limit: str = None,
         memory: str = None,
         memory_limit: str = None,
+        affinity: str = None,
         owner: str = '',
         **kwargs: dict,
     ) -> 'Task':
@@ -154,6 +155,7 @@ class Task(object):
             cpu_limit=cpu_limit if cpu_limit else self.taskdef.cpu_limit,
             memory=memory if memory else self.taskdef.memory,
             memory_limit=memory_limit if memory_limit else self.taskdef.memory_limit,
+            affinity=affinity if affinity else self.taskdef.affinity,
             owner=owner,
             inputs=serialize(inputs),
             storage=self.taskdef.storage,

--- a/test/engine/kubernetes/test_affinity.py
+++ b/test/engine/kubernetes/test_affinity.py
@@ -1,0 +1,62 @@
+from kubernetes import client
+from cowait.engine.const import LABEL_TASK_ID
+from cowait.engine.kubernetes.affinity import create_affinity
+
+
+def test_create_str_stack_affinity():
+    affinity = create_affinity('stack')
+    assert isinstance(affinity, client.V1Affinity)
+    assert affinity.pod_anti_affinity is None
+    item = affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution[0]
+    assert len(affinity.pod_affinity.required_during_scheduling_ignored_during_execution) == 0
+    assert item.weight == 1
+    term = item.pod_affinity_term
+    assert term.namespaces is None
+    assert term.topology_key == 'kubernetes.io/hostname'
+    expr = term.label_selector.match_expressions[0] 
+    assert expr.key == LABEL_TASK_ID
+    assert expr.operator == 'Exists'
+    assert expr.values == []
+
+
+def test_create_str_spread_affinity():
+    affinity = create_affinity('spread')
+    assert isinstance(affinity, client.V1Affinity)
+    assert affinity.pod_affinity is None
+    item = affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution[0]
+    assert len(affinity.pod_anti_affinity.required_during_scheduling_ignored_during_execution) == 0
+    assert item.weight == 1
+    term = item.pod_affinity_term
+    assert term.namespaces is None
+    assert term.topology_key == 'kubernetes.io/hostname'
+    expr = term.label_selector.match_expressions[0] 
+    assert expr.key == LABEL_TASK_ID
+    assert expr.operator == 'Exists'
+    assert expr.values == []
+
+
+def test_create_dict_affinity():
+    affinity = create_affinity({
+        'mode': 'stack',
+        'required': True,
+        'namespaces': ['default'],
+        'label': 'topology_key',
+        'weight': 90,
+        'selectors': [
+            {'key': 'task', 'operator': 'In', 'values': ['a', 'b']},
+        ],
+    })
+
+    assert isinstance(affinity, client.V1Affinity)
+    assert affinity.pod_anti_affinity is None
+    assert len(affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution) == 0
+    item = affinity.pod_affinity.required_during_scheduling_ignored_during_execution[0]
+    assert item.weight == 90
+    term = item.pod_affinity_term
+    assert term.namespaces == ['default']
+    assert term.topology_key == 'topology_key'
+    expr = term.label_selector.match_expressions[0] 
+    assert expr.key == 'task'
+    assert expr.operator == 'In'
+    assert expr.values == ['a', 'b']
+

--- a/test/tasks/test_definition.py
+++ b/test/tasks/test_definition.py
@@ -16,10 +16,11 @@ def test_taskdef_serialization():
         'storage':      {},
         'upstream':     None,
         'created_at':   '2020-02-02T20:00:02+00:00',
-        'cpu':          None,
-        'cpu_limit':    None,
-        'memory':       None,
-        'memory_limit': None,
+        'cpu':          '0.5',
+        'cpu_limit':    '2000m',
+        'memory':       '128m',
+        'memory_limit': '256m',
+        'affinity':     'stack',
         'owner':        'santa',
     }
 


### PR DESCRIPTION
Provides two basic affinity settings for tasks:

- `stack`: Attempt to schedule with other tasks (kubernetes PodAffinity)
- `spread`: Attempt to spread evenly across nodes (kubernetes PodAntiAffinity)

 The default mode is `spread`. Task affinity is inherited unless overridden by the `affinity` kwarg when calling `task.spawn()`.

Adds a `--affinity <mode>` argument to `cowait run`.

`--affinity spread` is equivalent to:
```yml
cowait:
  affinity:
    - mode: spread
      required: false
      namespaces:
        - default
      label: kubernetes.io/hostname
      selectors:
        - key: cowait/task
          operator: Exists
```

`--affinity stack` is equivalent to:
```yml
cowait:
  affinity:
    - mode: stack
      required: false
      namespaces:
        - default
      label: kubernetes.io/hostname
      selectors:
        - key: cowait/task
          operator: Exists
```

resolve #101 