### PR TITLE
Disable websocket autoping

### DIFF
--- a/cowait/network/client.py
+++ b/cowait/network/client.py
@@ -73,11 +73,11 @@ class Client(EventEmitter):
                             raise SocketError(ws.exception())
                         elif msg.type == WSMsgType.BINARY:
                             raise SocketError('Unexpected binary message')
-
-                        event = msg.json()
-                        if self.rpc.intercept_event(**event):
-                            continue
-                        await self.emit(**event, conn=self)
+                        elif msg.type == WSMsgType.TEXT:
+                            event = msg.json()
+                            if self.rpc.intercept_event(**event):
+                                continue
+                            await self.emit(**event, conn=self)
 
                     await self.emit(ON_CLOSE, conn=self)
 

--- a/cowait/network/client.py
+++ b/cowait/network/client.py
@@ -50,7 +50,7 @@ class Client(EventEmitter):
             async with session.ws_connect(
                 url,
                 headers={'Authorization': f'Bearer {token}'},
-                autoping=True,
+                autoping=False,
                 heartbeat=5.0,
                 timeout=30.0,
             ) as ws:

--- a/cowait/network/server.py
+++ b/cowait/network/server.py
@@ -54,11 +54,11 @@ class Server(EventEmitter):
                     raise SocketError(ws.exception())
                 elif msg.type == WSMsgType.BINARY:
                     raise SocketError('Unexpected binary message')
-
-                event = msg.json()
-                if conn.rpc.intercept_event(**event):
-                    continue
-                await self.emit(**event, conn=conn)
+                elif msg.type == WSMsgType.TEXT:
+                    event = msg.json()
+                    if conn.rpc.intercept_event(**event):
+                        continue
+                    await self.emit(**event, conn=conn)
 
             await self.emit(type=ON_CLOSE, conn=conn)
 

--- a/cowait/network/server.py
+++ b/cowait/network/server.py
@@ -36,7 +36,7 @@ class Server(EventEmitter):
     async def handle_client(self, request):
         ws = web.WebSocketResponse(
             timeout=30.0,
-            autoping=True,
+            autoping=False,
             heartbeat=5.0,
         )
         await ws.prepare(request)

--- a/examples/06-tensorflow/test_mnist.py
+++ b/examples/06-tensorflow/test_mnist.py
@@ -2,7 +2,7 @@ import pytest
 from mnist import MnistTask
 
 
-@pytest.mark.async_timeout(180)
+@pytest.mark.async_timeout(300)
 async def test_number():
     result = await MnistTask()
     assert result == 9


### PR DESCRIPTION
There seems to be a bug in `aiohttp` that causes unhandled exceptions. This PR disables the autoping feature until this is fixed.

Also ensures that websocket frames with a type other than `TEXT` are never json decoded.

resolve #235 