### PR TITLE
Wait for unschedulable Kubernetes tasks

### DIFF
--- a/cowait/cli/commands/cluster.py
+++ b/cowait/cli/commands/cluster.py
@@ -57,7 +57,7 @@ def cluster_rm(config: Config, name: str) -> None:
         return 1
 
     if name == config.default_cluster:
-        print('Error: Cant remove the default cluster')
+        print('Error: Cant remove the current default cluster')
         return 1
 
     if name == 'docker':

--- a/cowait/cli/task_image.py
+++ b/cowait/cli/task_image.py
@@ -62,7 +62,8 @@ class TaskImage(object):
         logs = client.images.push(
             repository=self.name,
             tag='latest',
-            stream=True
+            stream=True,
+            decode=True,
         )
         return logs
 

--- a/cowait/engine/kubernetes/errors.py
+++ b/cowait/engine/kubernetes/errors.py
@@ -1,0 +1,13 @@
+
+
+class PodUnschedulableError(Exception):
+    pass
+
+
+class PodTerminatedError(Exception):
+    pass
+
+
+class ImagePullError(Exception):
+    pass
+

--- a/cowait/engine/kubernetes/kubernetes.py
+++ b/cowait/engine/kubernetes/kubernetes.py
@@ -13,6 +13,8 @@ from .task import KubernetesTask
 from .volumes import create_volumes
 from .utils import create_ports
 from .affinity import create_affinity
+from .pod import pod_is_running, pod_is_terminated, pod_is_creating, \
+    pod_is_unschedulable, pod_image_pull_failed
 
 DEFAULT_NAMESPACE = 'default'
 DEFAULT_SERVICE_ACCOUNT = 'default'
@@ -149,38 +151,28 @@ class KubernetesProvider(ClusterProvider):
     def wait(self, task: KubernetesTask) -> bool:
         raise NotImplementedError()
 
-    def wait_until_ready(self, task_id: str, poll_interval: float = 0.5):
-        timeout = self.timeout
+    def wait_until_ready(self, task_id: str, poll_interval: float = 1):
         while True:
             time.sleep(poll_interval)
             pod = self.get_task_pod(task_id)
 
-            statuses = pod.status.container_statuses
-            if statuses is not None and len(statuses) > 0:
-                state = statuses[0].state
+            if pod_is_running(pod):
+                break
 
-                # check for termination errors
-                if state.terminated is not None:
-                    raise TaskCreationError(
-                        f'Pod terminated: {state.terminated.reason}\n'
-                        f'{state.terminated.message}')
+            if pod_is_creating(pod):
+                continue
+            
+            if pod_is_terminated(pod):
+                raise TaskCreationError('Task terminated')
+            
+            if pod_image_pull_failed(pod):
+                self.kill(task_id)
+                raise TaskCreationError('Image pull failed')
 
-                # check waiting state
-                if state.waiting is not None:
-                    # abort if the image is not available
-                    if state.waiting.reason == 'ErrImagePull':
-                        self.kill(task_id)
-                        raise TaskCreationError(
-                            f'Image pull failed\n'
-                            f'{state.waiting.message}')
-
-                # we are go
-                if state.running is not None:
-                    break
-
-            timeout -= poll_interval
-            if timeout <= 0:
-                raise TimeoutError(f'Could not find pod for {task_id}')
+            if pod_is_unschedulable(pod):
+                poll_interval = 10
+                print(f'warning: task {task_id} is unschedulable')
+                continue
 
     def logs(self, task: KubernetesTask):
         if not isinstance(task, KubernetesTask):

--- a/cowait/engine/kubernetes/pod.py
+++ b/cowait/engine/kubernetes/pod.py
@@ -1,52 +1,34 @@
+from .errors import PodTerminatedError, PodUnschedulableError, ImagePullError
 
 
-def pod_is_unschedulable(pod):
-    for cond in pod.status.conditions:
-        if cond.type == 'PodScheduled' and cond.status == 'False':
+def pod_is_ready(pod):
+    if pod.status.conditions:
+        for cond in pod.status.conditions:
+            if cond.type == 'PodScheduled' and cond.status == 'False':
+                raise PodUnschedulableError(cond.message)
+
+    statuses = pod.status.container_statuses
+    if statuses is None:
+        return False
+
+    for status in statuses:
+        state = status.state
+
+        if state.running is not None:
             return True
+
+        if state.terminated is not None:
+            raise PodTerminatedError()
+
+        if state.waiting is not None:
+            if state.waiting.reason == 'ContainerCreating':
+                return False
+
+            if state.waiting.reason == 'ErrImagePull':
+                raise ImagePullError(state.waiting.message)
+
+            if state.waiting.reason == 'ImagePullBackoff':
+                raise ImagePullError(state.waiting.message)
+
     return False
 
-
-def pod_is_terminated(pod):
-    statuses = pod.status.container_statuses
-    if statuses is None:
-        return False
-    for status in statuses:
-        if status.state.terminated is not None:
-            return True
-    return False
-
-
-def pod_is_creating(pod):
-    statuses = pod.status.container_statuses
-    if statuses is None:
-        return False
-    for status in statuses:
-        if status.state.waiting is not None:
-            if status.state.waiting.reason == 'ContainerCreating':
-                return True
-    return False
-
-
-def pod_is_running(pod):
-    statuses = pod.status.container_statuses
-    if statuses is None:
-        return False
-    for status in statuses:
-        if status.state.running is not None:
-            return True
-    return False
-
-
-def pod_image_pull_failed(pod):
-    statuses = pod.status.container_statuses
-    if statuses is None:
-        return False
-    for status in statuses:
-        if status.state.waiting is not None:
-            # abort if the image is not available
-            if status.state.waiting.reason == 'ErrImagePull':
-                return True
-            if status.state.waiting.reason == 'ImagePullBackoff':
-                return True
-    return False

--- a/cowait/engine/kubernetes/pod.py
+++ b/cowait/engine/kubernetes/pod.py
@@ -1,0 +1,52 @@
+
+
+def pod_is_unschedulable(pod):
+    for cond in pod.status.conditions:
+        if cond.type == 'PodScheduled' and cond.status == 'False':
+            return True
+    return False
+
+
+def pod_is_terminated(pod):
+    statuses = pod.status.container_statuses
+    if statuses is None:
+        return False
+    for status in statuses:
+        if status.state.terminated is not None:
+            return True
+    return False
+
+
+def pod_is_creating(pod):
+    statuses = pod.status.container_statuses
+    if statuses is None:
+        return False
+    for status in statuses:
+        if status.state.waiting is not None:
+            if status.state.waiting.reason == 'ContainerCreating':
+                return True
+    return False
+
+
+def pod_is_running(pod):
+    statuses = pod.status.container_statuses
+    if statuses is None:
+        return False
+    for status in statuses:
+        if status.state.running is not None:
+            return True
+    return False
+
+
+def pod_image_pull_failed(pod):
+    statuses = pod.status.container_statuses
+    if statuses is None:
+        return False
+    for status in statuses:
+        if status.state.waiting is not None:
+            # abort if the image is not available
+            if status.state.waiting.reason == 'ErrImagePull':
+                return True
+            if status.state.waiting.reason == 'ImagePullBackoff':
+                return True
+    return False

--- a/cowait/engine/kubernetes/task.py
+++ b/cowait/engine/kubernetes/task.py
@@ -1,5 +1,9 @@
+import asyncio
 from cowait.tasks import TaskDefinition, RemoteTask
 from cowait.engine.cluster import ClusterProvider
+from cowait.engine.errors import TaskCreationError
+from .pod import pod_is_running, pod_is_terminated, pod_is_creating, \
+    pod_is_unschedulable, pod_image_pull_failed
 
 
 class KubernetesTask(RemoteTask):
@@ -18,3 +22,29 @@ class KubernetesTask(RemoteTask):
 
     def __str__(self):
         return f'KubernetesTask({self.id}, {self.status}, {self.inputs})'
+
+    async def wait_for_scheduling(self):
+        poll_interval = 0
+        while True:
+            await asyncio.sleep(poll_interval)
+            pod = self.cluster.get_task_pod(self.id)
+
+            if pod_is_running(pod):
+                break
+
+            if pod_is_creating(pod):
+                poll_interval = 1
+                continue
+            
+            if pod_is_terminated(pod):
+                raise TaskCreationError('Task terminated')
+            
+            if pod_image_pull_failed(pod):
+                self.cluster.kill(self.id)
+                raise TaskCreationError('Image pull failed')
+
+            if pod_is_unschedulable(pod):
+                poll_interval = 10
+                print('warning: task', self.id, 'is unschedulable')
+                continue
+

--- a/cowait/tasks/remote_task.py
+++ b/cowait/tasks/remote_task.py
@@ -58,9 +58,14 @@ class RemoteTask(TaskInstance):
         if not self.future.done():
             self.future.set_result(result)
 
+    async def wait_for_scheduling(self) -> None:
+        pass
+
     async def wait_for_init(self, timeout=30) -> None:
         if self.status != WAIT:
             raise RuntimeError(f'Cant await task with status {self.status}')
+
+        await self.wait_for_scheduling()
 
         slept = 0
         interval = 0.2

--- a/test/tasks/components/test_task_manager.py
+++ b/test/tasks/components/test_task_manager.py
@@ -1,0 +1,169 @@
+import pytest
+from unittest.mock import Mock
+from cowait.test import AsyncMock
+from cowait.tasks.status import DONE, WORK
+from cowait.tasks.messages import TASK_INIT, TASK_STATUS, TASK_FAIL, TASK_RETURN
+from cowait.tasks.components import TaskManager
+from cowait.utils import EventEmitter
+from cowait.version import version
+
+
+class MockTask(object):
+    def __init__(self, id: str = '123'):
+        self.id = id
+        self.status = WORK
+        self.node = Mock()
+        self.cluster = Mock()
+        self.taskdef = Mock()
+        self.future = Mock()
+
+
+def test_task_event_registration():
+    task = MockTask()
+    mgr = TaskManager(task)
+    task.node.server.on.assert_any_call(TASK_INIT, mgr.on_child_init)
+    task.node.server.on.assert_any_call(TASK_STATUS, mgr.on_child_status)
+    task.node.server.on.assert_any_call(TASK_FAIL, mgr.on_child_fail)
+    task.node.server.on.assert_any_call(TASK_RETURN, mgr.on_child_return)
+
+
+async def test_task_message_forward():
+    task = MockTask()
+    task.node.server = EventEmitter()
+    task.node.parent.send = AsyncMock()
+    TaskManager(task)
+    await task.node.server.emit('something', conn=AsyncMock())
+    assert task.node.parent.send.called
+
+
+async def test_task_watch_timeout():
+    parent, child = MockTask(), MockTask()
+    mgr = TaskManager(parent)
+    mgr.emit_child_error = AsyncMock()
+    child.wait_for_scheduling = AsyncMock()
+    child.future.done = Mock(return_value=False)
+    await mgr._init_timeout_check(child, 0)
+    child.wait_for_scheduling.assert_called()
+    parent.cluster.kill.assert_called_with(child.id)
+    mgr.emit_child_error.assert_called()
+
+
+async def test_task_watch_completed():
+    parent, child = MockTask(), MockTask()
+    mgr = TaskManager(parent)
+    mgr.emit_child_error = AsyncMock()
+    mgr.conns[child.id] = Mock()
+    child.wait_for_scheduling = AsyncMock()
+    child.future.done = Mock(return_value=True)
+    await mgr._init_timeout_check(child, 0)
+    child.wait_for_scheduling.assert_called()
+    parent.cluster.kill.assert_not_called()
+    mgr.emit_child_error.assert_not_called()
+
+
+async def test_task_watch_ok():
+    parent, child = MockTask(), MockTask()
+    mgr = TaskManager(parent)
+    mgr.conns[Mock()] = child.id # register connection
+    mgr.emit_child_error = AsyncMock()
+    child.wait_for_scheduling = AsyncMock()
+    child.future.done = Mock(return_value=False)
+    await mgr._init_timeout_check(child, 0)
+    child.wait_for_scheduling.assert_called()
+    parent.cluster.kill.assert_not_called()
+    mgr.emit_child_error.assert_not_called()
+
+
+async def test_version_check_reject():
+    parent = MockTask()
+    conn = Mock()
+    mgr = TaskManager(parent)
+    mgr.reject = AsyncMock()
+    mgr.register = Mock()
+    await mgr.on_child_init(conn, id='abc', task={}, version='invalid')
+    mgr.reject.assert_called()
+    mgr.register.assert_not_called()
+
+
+async def test_version_check_accept():
+    parent = MockTask()
+    conn = Mock()
+    mgr = TaskManager(parent)
+    mgr.reject = AsyncMock()
+    mgr.register = Mock()
+    await mgr.on_child_init(conn, id='abc', task={}, version=version)
+    mgr.reject.assert_not_called()
+    mgr.register.assert_called()
+
+
+async def test_task_register_watched():
+    conn = Mock()
+    parent, child = MockTask(), MockTask()
+    mgr = TaskManager(parent)
+    mgr[child.id] = child
+
+    mgr.register(conn, child.id, {
+        'id': str(child.id),
+        'name': 'child',
+        'image': 'test',
+    })
+
+    # connection should be stored
+    assert conn in mgr.conns
+
+    # task connection reference should be set
+    assert mgr[child.id].conn == conn
+
+
+async def test_task_register_virtual():
+    conn = Mock()
+    parent, child = MockTask(), MockTask()
+    mgr = TaskManager(parent)
+
+    assert child.id not in mgr
+
+    mgr.register(conn, child.id, {
+        'id': child.id,
+        'name': 'child',
+        'image': 'test',
+        'parent': parent.id,
+    })
+
+    # connection should be stored
+    assert conn in mgr.conns
+
+    # a remote task instance should be created
+    assert child.id in mgr
+    assert mgr[child.id].conn == conn
+
+
+async def test_child_disconnect():
+    conn = Mock()
+    parent, child = MockTask(), MockTask()
+    mgr = TaskManager(parent)
+    child.conn = conn
+    child.status = DONE
+    mgr.conns[conn] = child.id
+    mgr[child.id] = child
+    mgr.emit_child_error = AsyncMock()
+
+    await mgr.on_child_close(conn)
+    assert child.conn is None
+    assert conn not in mgr.conns
+    mgr.emit_child_error.assert_not_called()
+
+
+async def test_child_lost():
+    conn = Mock()
+    parent, child = MockTask(), MockTask()
+    mgr = TaskManager(parent)
+    child.conn = conn
+    mgr.conns[conn] = child.id
+    mgr[child.id] = child
+    mgr.emit_child_error = AsyncMock()
+
+    await mgr.on_child_close(conn)
+    assert child.conn is None
+    assert conn not in mgr.conns
+    mgr.emit_child_error.assert_called()
+


### PR DESCRIPTION
Changes the default behavior of task timeouts. Cowait will now wait for indefinitely as long as no error (such as unavailable images etc) occur. 

resolve #243 