### PR TITLE
Log command & Engine cleanup

### DIFF
--- a/cowait/cli/app/root.py
+++ b/cowait/cli/app/root.py
@@ -19,6 +19,7 @@ def new_cli_app():
     cli.add_command(task.agent)
     cli.add_command(task.notebook)
     cli.add_command(task.test)
+    cli.add_command(task.logs)
 
     # image commands
     cli.add_command(image.build)

--- a/cowait/cli/app/task.py
+++ b/cowait/cli/app/task.py
@@ -193,3 +193,19 @@ def agent(ctx, cluster: str, detach: bool, upstream: str):
 @click.pass_context
 def notebook(ctx, cluster, build, image):
     cowait.cli.notebook(ctx.obj, build, image, cluster_name=cluster)
+
+
+@click.command(help='stream logs from a running task')
+@click.option('-c', '--cluster',
+              default=None,
+              type=str,
+              help='cluster name')
+@click.option('-r', '--raw',
+              type=bool, is_flag=True,
+              help='raw output',
+              default=False)
+@click.argument('task', type=str)
+@click.pass_context
+def logs(ctx, cluster: str, raw: bool, task: str):
+    cowait.cli.logs(ctx.obj, task, cluster_name=cluster, raw=raw)
+

--- a/cowait/cli/commands/__init__.py
+++ b/cowait/cli/commands/__init__.py
@@ -9,4 +9,4 @@ from .test import test
 from .notebook import notebook
 from .cluster import *
 
-from .misc import *
+from .task import *

--- a/cowait/cli/commands/run.py
+++ b/cowait/cli/commands/run.py
@@ -107,7 +107,7 @@ def run(
 
         with ExitTrap(destroy):
             # capture & print logs
-            logs = cluster.logs(task)
+            logs = cluster.logs(task.id)
             logger.header('task output')
             for msg in logs:
                 logger.handle(msg)

--- a/cowait/cli/commands/task.py
+++ b/cowait/cli/commands/task.py
@@ -1,6 +1,7 @@
 from ..config import Config
 from ..context import Context
 from cowait.engine import ProviderError
+from .run import RunLogger
 
 
 def destroy(config: Config, *, cluster_name: str = None) -> None:
@@ -19,21 +20,39 @@ def list_tasks(config: Config, *, cluster_name: str = None) -> None:
         cluster = context.get_cluster(cluster_name)
         tasks = cluster.list_all()
         for task in tasks:
-            print(task)
+            print(task.id)
 
     except ProviderError as e:
         print('Provider error:', str(e))
 
 
-def kill(config: Config, partial_task_id: str):
+def kill(config: Config, partial_task_id: str, cluster_name: str):
     """ Kills all tasks that somewhat matches partial_task_id """
     try:
-        cluster = config.get_cluster()
+        context = Context.open(config)
+        cluster = context.get_cluster(cluster_name)
         tasks = cluster.list_all()
         for task in tasks:
-            if partial_task_id in str(task):
-                cluster.destroy(str(task))
-                print('killed ', str(task))
+            if partial_task_id in task.id:
+                cluster.destroy(task.id)
+                print('killed ', task.id)
 
     except ProviderError as e:
         print('Provider error:', str(e))
+
+
+def logs(config: Config, task_id: str, cluster_name: str, raw: bool = False):
+    try:
+        context = Context.open(config)
+        cluster = context.get_cluster(cluster_name)
+    
+        logs = cluster.logs(task_id)
+        logger = RunLogger(raw)
+        logger.header('task output')
+        for msg in logs:
+            logger.handle(msg)
+        logger.header()
+
+    except ProviderError as e:
+        print('Provider error:', str(e))
+

--- a/cowait/cli/commands/test.py
+++ b/cowait/cli/commands/test.py
@@ -37,7 +37,7 @@ def test(
 
         with ExitTrap(destroy):
             # capture & print logs
-            logs = cluster.logs(task)
+            logs = cluster.logs(task.id)
             logger.header('task output')
             for msg in logs:
                 logger.handle(msg)

--- a/cowait/engine/cluster.py
+++ b/cowait/engine/cluster.py
@@ -38,7 +38,7 @@ class ClusterProvider(EventEmitter):
         raise NotImplementedError()
 
     @abstractmethod
-    def logs(self, task: RemoteTask) -> Iterable[str]:
+    def logs(self, task_id: str) -> Iterable[str]:
         """ Stream logs from task """
         raise NotImplementedError()
 
@@ -53,33 +53,6 @@ class ClusterProvider(EventEmitter):
             **self.args,
         }
 
-    def create_env(self, taskdef: TaskDefinition) -> dict:
-        """
-        Create a container environment dict from a task definition.
-
-        Arguments:
-            taskdef (TaskDefinition): Task definition
-
-        Returns:
-            env (dict): Environment variable dict
-        """
-
-        env = {
-            **taskdef.env,
-            ENV_GZIP_ENABLED:    '1',
-            ENV_TASK_CLUSTER:    env_pack(self.serialize()),
-            ENV_TASK_DEFINITION: env_pack(taskdef.serialize()),
-        }
-
-        # check total length of environment data
-        length = 0
-        for key, value in env.items():
-            length += len(str(key)) + len(str(value))
-
-        if length > MAX_ENV_LENGTH:
-            raise ProviderError(f'Task environment too long. Was {length}, max: {MAX_ENV_LENGTH}')
-
-        return env
-
     def find_agent(self):
         return None
+

--- a/cowait/engine/docker/utils.py
+++ b/cowait/engine/docker/utils.py
@@ -1,0 +1,31 @@
+from cowait.tasks import TaskDefinition
+from cowait.engine.const import ENV_TASK_DEFINITION, MAX_ENV_LENGTH
+from cowait.engine.utils import env_unpack, base_environment
+from cowait.engine.errors import ProviderError
+
+
+def create_ports(taskdef):
+    return taskdef.ports
+
+
+def create_env(cluster, taskdef):
+    env = base_environment(cluster, taskdef)
+
+    # check total length of environment data
+    length = 0
+    for key, value in env.items():
+        length += len(str(key)) + len(str(value))
+
+    if length > MAX_ENV_LENGTH:
+        raise ProviderError(f'Task environment too long. Was {length}, max: {MAX_ENV_LENGTH}')
+
+    return env
+
+
+def extract_container_taskdef(container) -> TaskDefinition:
+    for env in container.attrs['Config']['Env']:
+        if ENV_TASK_DEFINITION == env[0:len(ENV_TASK_DEFINITION)]:
+            data = env[len(ENV_TASK_DEFINITION)+1:]
+            return TaskDefinition(**env_unpack(data))
+    raise Exception('Unable to unpack container task definition')
+

--- a/cowait/engine/kubernetes/pod.py
+++ b/cowait/engine/kubernetes/pod.py
@@ -1,3 +1,7 @@
+import json
+from cowait.tasks import TaskDefinition
+from cowait.engine.const import ENV_TASK_DEFINITION
+from cowait.engine.utils import env_unpack
 from .errors import PodTerminatedError, PodUnschedulableError, ImagePullError
 
 
@@ -31,4 +35,13 @@ def pod_is_ready(pod):
                 raise ImagePullError(state.waiting.message)
 
     return False
+
+
+def extract_pod_taskdef(pod) -> TaskDefinition:
+    for container in pod.spec.containers:
+        for env in container.env:
+            if env.name == ENV_TASK_DEFINITION:
+                taskdef = env_unpack(env.value)
+                return TaskDefinition(**taskdef)
+    raise Exception('Failed to extract pod task definition')
 

--- a/cowait/engine/kubernetes/utils.py
+++ b/cowait/engine/kubernetes/utils.py
@@ -1,5 +1,15 @@
 from kubernetes import client
+from cowait.tasks import TaskDefinition
 from cowait.engine.const import LABEL_TASK_ID
+from cowait.engine.utils import base_environment
+
+
+def create_env(cluster, taskdef: TaskDefinition):
+    env = base_environment(cluster, taskdef)
+    return [
+        client.V1EnvVar(str(name), str(value))
+        for name, value in env.items()
+    ]
 
 
 def create_ports(ports: dict) -> list:

--- a/cowait/engine/utils.py
+++ b/cowait/engine/utils.py
@@ -1,6 +1,8 @@
 import json
 import gzip
 from base64 import b64encode, b64decode
+from cowait.tasks import TaskDefinition
+from .const import ENV_TASK_CLUSTER, ENV_TASK_DEFINITION, ENV_GZIP_ENABLED
 
 
 def env_pack(value):
@@ -13,3 +15,23 @@ def env_unpack(value):
     value = b64decode(value)
     value = gzip.decompress(value)
     return json.loads(value)
+
+
+def base_environment(cluster, taskdef: TaskDefinition) -> dict:
+    """
+    Create a container environment dict from a task definition.
+
+    Arguments:
+        taskdef (TaskDefinition): Task definition
+
+    Returns:
+        env (dict): Environment variable dict
+    """
+
+    return {
+        **taskdef.env,
+        ENV_GZIP_ENABLED:    '1',
+        ENV_TASK_CLUSTER:    env_pack(cluster.serialize()),
+        ENV_TASK_DEFINITION: env_pack(taskdef.serialize()),
+    }
+

--- a/cowait/tasks/remote_task.py
+++ b/cowait/tasks/remote_task.py
@@ -98,7 +98,7 @@ class RemoteTask(TaskInstance):
         await self.call('stop')
 
     def logs(self):
-        return self.cluster.logs(self)
+        return self.cluster.logs(self.id)
 
     def __getattr__(self, method):
         async def magic_rpc(*args, **kwargs):

--- a/test/engine/docker/test_docker.py
+++ b/test/engine/docker/test_docker.py
@@ -111,8 +111,9 @@ def test_docker_child_task():
 
     # test list tasks
     tasks = dp.list_all()
-    assert task.id in tasks
-    assert child.labels[LABEL_TASK_ID] in tasks
+    task_ids = list(map(lambda t: t.id, tasks))
+    assert task.id in task_ids
+    assert child.labels[LABEL_TASK_ID] in task_ids
 
     # kill the whole family
     dp.destroy(task.id)

--- a/test/engine/docker/test_docker_util.py
+++ b/test/engine/docker/test_docker_util.py
@@ -4,6 +4,7 @@ from cowait.engine.cluster import ClusterProvider
 from cowait.engine.errors import ProviderError
 from cowait.tasks import TaskDefinition
 from cowait.utils import uuid
+from cowait.engine.docker.utils import create_env
 
 
 def test_max_env_length():
@@ -12,10 +13,11 @@ def test_max_env_length():
 
     with pytest.raises(ProviderError):
         cp = ClusterProvider('test')
-        cp.create_env(TaskDefinition(
+        create_env(cp, TaskDefinition(
             'test-task',
             image='imaginary-image',
             inputs={
                 'ohshit': random_data,
             },
         ))
+


### PR DESCRIPTION
- Changed `ClusterProvider.logs()` to take a task id string instead of a task object as its parameter 
- Added `cowait logs <task id>` to attach to a log output of a detached container
- Fixed `cowait kill` command

resolve #248 