### PR TITLE
Custom dockerfile names and wildcard-kill

### DIFF
--- a/cowait/cli/app/image.py
+++ b/cowait/cli/app/image.py
@@ -24,8 +24,12 @@ from .utils import parse_input_list
               type=bool, is_flag=True,
               help='push image after building',
               default=False)
+@click.option('-d', '--dockerfile',
+              default='Dockerfile',
+              type=str,
+              help='path and name of dockerfile')
 @click.pass_context
-def build(ctx, quiet: bool, workdir: str, image: str, arg: dict, push: bool):
+def build(ctx, quiet: bool, workdir: str, image: str, arg: dict, push: bool, dockerfile: str):
     cowait.cli.build(
         ctx.obj,
         quiet=quiet,
@@ -33,6 +37,7 @@ def build(ctx, quiet: bool, workdir: str, image: str, arg: dict, push: bool):
         image_name=image,
         buildargs=parse_input_list(arg),
         push=push,
+        dockerfile_name=dockerfile,
     )
 
 

--- a/cowait/cli/app/task.py
+++ b/cowait/cli/app/task.py
@@ -159,26 +159,6 @@ def ps(ctx, cluster: str):
 def kill(ctx, cluster: str, task: str):
     cowait.cli.kill(ctx.obj, task, cluster_name=cluster)
 
-@click.command(help='kill tasks by wildcard-search on id')
-@click.argument('partial_task_id', type=str)
-@click.option('-c', '--cluster',
-              default=None,
-              type=str,
-              help='cluster name')
-@click.pass_context
-def kill_name_search(ctx, partial_task_id: str, cluster: str):
-    """Kills all tasks that somewhat matches partial_task_id     
-    """
-    try:
-        tasks = cowait.cli.list_tasks(ctx.obj, cluster_name=cluster)
-        for task in tasks:
-            if partial_task_id in str(task):
-                cowait.cli.kill(ctx.obj, task, cluster_name=cluster)
-                print('Killed ', str(task))
-
-    except ProviderError as e:
-        print('Provider error:', str(e))
-
 @click.command(help='deploy cowait agent')
 @click.option('-c', '--cluster',
               default=None,

--- a/cowait/cli/app/task.py
+++ b/cowait/cli/app/task.py
@@ -159,6 +159,25 @@ def ps(ctx, cluster: str):
 def kill(ctx, cluster: str, task: str):
     cowait.cli.kill(ctx.obj, task, cluster_name=cluster)
 
+@click.command(help='kill tasks by wildcard-search on id')
+@click.argument('partial_task_id', type=str)
+@click.option('-c', '--cluster',
+              default=None,
+              type=str,
+              help='cluster name')
+@click.pass_context
+def kill_name_search(ctx, partial_task_id: str, cluster: str):
+    """Kills all tasks that somewhat matches partial_task_id     
+    """
+    try:
+        tasks = cowait.cli.list_tasks(ctx.obj, cluster_name=cluster)
+        for task in tasks:
+            if partial_task_id in str(task):
+                cowait.cli.kill(ctx.obj, task, cluster_name=cluster)
+                print('Killed ', str(task))
+
+    except ProviderError as e:
+        print('Provider error:', str(e))
 
 @click.command(help='deploy cowait agent')
 @click.option('-c', '--cluster',

--- a/cowait/cli/commands/build.py
+++ b/cowait/cli/commands/build.py
@@ -18,6 +18,7 @@ def build(
     buildargs: dict = {},
     quiet: bool = False,
     push: bool = False,
+    dockerfile_name: str = 'Dockerfile',
 ) -> TaskImage:
     logger = Logger(quiet)
     try:
@@ -53,7 +54,7 @@ def build(
         # find custom Dockerfile
         # if it exists, build and extend that instead of the default base image
         base_image = context.base
-        dockerfile = context.file('Dockerfile')
+        dockerfile = context.file_root(dockerfile_name)
         if dockerfile:
             logger.println('* Found custom Dockerfile:', context.relpath(dockerfile))
 

--- a/cowait/cli/context.py
+++ b/cowait/cli/context.py
@@ -60,6 +60,16 @@ class Context(Config):
         """
         return os.path.relpath(context_path, self.root_path)
 
+    def file_root(self, file_name: str) -> str:
+        """
+        Find a file within the root path of the task and return its full path
+        """
+        path = os.path.join(self.root_path, file_name)
+        if not os.path.isfile(path):
+            return None
+
+        return path
+
     def includes(self, path: str) -> bool:
         """
         Checks if the path is included in the context


### PR DESCRIPTION
We have tasks that need different builds, such as maven, npm etc. We simply name the dockerfiles differently to make the images slimmer where each dockerfile only contains its minimal needed environment. 