### PR TITLE
Increase max-length of env-variables

### DIFF
--- a/cowait/engine/const.py
+++ b/cowait/engine/const.py
@@ -22,4 +22,5 @@ LABEL_PARENT_ID = 'cowait/parent'
 # ---------------------------------------------------
 
 # Maximum length of environment variables, 100kB
-MAX_ENV_LENGTH = 100 * 1024
+MAX_ENV_LENGTH = 500 * 1024
+


### PR DESCRIPTION
At Debricked, we are using some quite long secrets :) Some configurations we have are done through jsonified configurations, which results in some long strings for envs.