### PR TITLE
Test command fixes

### DIFF
--- a/cowait/cli/app/task.py
+++ b/cowait/cli/app/task.py
@@ -128,13 +128,9 @@ def run(
               default=None,
               type=str,
               help='cluster name')
-@click.option('--push',
-              type=bool, is_flag=True,
-              help='build and push first',
-              default=False)
 @click.pass_context
-def test(ctx, cluster: str, push: bool):
-    cowait.cli.test(ctx.obj, push, cluster_name=cluster)
+def test(ctx, cluster: str):
+    cowait.cli.test(ctx.obj, cluster_name=cluster)
 
 
 @click.command(help='destroy tasks')

--- a/cowait/cli/commands/test.py
+++ b/cowait/cli/commands/test.py
@@ -1,4 +1,5 @@
 import sys
+import getpass
 from cowait.tasks import TaskDefinition, TASK_LOG
 from cowait.engine import ProviderError, TaskCreationError
 from ..config import Config
@@ -22,6 +23,12 @@ def test(
         task = cluster.spawn(TaskDefinition(
             name='cowait.test',
             image=context.image,
+            owner=getpass.getuser(),
+            env={
+                **context.environment,
+                **context.dotenv,
+            },
+            volumes=context.get('volumes', {}),
         ))
 
         def destroy(*args):

--- a/cowait/cli/commands/test.py
+++ b/cowait/cli/commands/test.py
@@ -11,18 +11,12 @@ from .push import push as run_push
 
 def test(
     config: Config,
-    push: bool,
     cluster_name: str = None,
 ):
     logger = TestLogger()
     try:
         context = Context.open(config)
         cluster = context.get_cluster(cluster_name)
-
-        if push:
-            run_push(config)
-        else:
-            run_build(config)
 
         # execute the test task within the current image
         task = cluster.spawn(TaskDefinition(

--- a/cowait/engine/kubernetes/kubernetes.py
+++ b/cowait/engine/kubernetes/kubernetes.py
@@ -275,3 +275,17 @@ class KubernetesProvider(ClusterProvider):
         token = pod.metadata.labels['http_token']
         return get_remote_url(pod.status.pod_ip, token)
 
+    def wait(self, task: KubernetesTask) -> bool:
+        while True:
+            pod = self.get_task_pod(task.id)
+            if pod is None:
+                return False
+
+            if pod.status.phase == 'Running':
+                time.sleep(2)
+            elif pod.status.phase == 'Pending':
+                time.sleep(2)
+            elif pod.status.phase == 'Succeeded':
+                return True
+            else:
+                return False

--- a/examples/test_examples.sh
+++ b/examples/test_examples.sh
@@ -14,6 +14,9 @@ do
     echo "~~ Running tests in $dir"
     cd $dir
 
+    # build
+    cowait build
+
     # run tests
     cowait test
     if [ "$?" != "0" ]; then


### PR DESCRIPTION
- Remove built-in `build` and `push` functionality from `cowait test`
- Pass `environment` and `volumes` configuration when running `cowait test`
- Implement `KubernetesProvider.wait()` so that tests may run on kubernetes clusters. `wait()` should probably be removed or changes, since its API currently breaks the convention of passing task ids to `ClusterProvider` methods.