### PR TITLE
cowait test correctly mounts the context root when running locally

### DIFF
--- a/cowait/cli/app/task.py
+++ b/cowait/cli/app/task.py
@@ -128,9 +128,13 @@ def run(
               default=None,
               type=str,
               help='cluster name')
+@click.option('-m', '--mount/--no-mount',
+              default=True,
+              type=bool,
+              help='mount working directory')
 @click.pass_context
-def test(ctx, cluster: str):
-    cowait.cli.test(ctx.obj, cluster_name=cluster)
+def test(ctx, cluster: str, mount: bool):
+    cowait.cli.test(ctx.obj, cluster_name=cluster, mount=mount)
 
 
 @click.command(help='destroy tasks')

--- a/cowait/cli/commands/test.py
+++ b/cowait/cli/commands/test.py
@@ -13,6 +13,7 @@ from .push import push as run_push
 def test(
     config: Config,
     cluster_name: str = None,
+    mount: bool = True,
 ):
     logger = TestLogger()
     try:
@@ -20,9 +21,10 @@ def test(
         cluster = context.get_cluster(cluster_name)
 
         volumes = {}
-        if cluster.type == 'docker':
+        if mount and cluster.type == 'docker':
             # when testing in docker, mount the local directory
             # this avoids the problem of having to constantly rebuild in order to test
+            print('** Mounting', context.root_path)
             volumes['/var/task'] = {
                 'bind': {
                     'src': context.root_path,

--- a/examples/test_examples.sh
+++ b/examples/test_examples.sh
@@ -18,7 +18,7 @@ do
     cowait build
 
     # run tests
-    cowait test
+    cowait test --no-mount
     if [ "$?" != "0" ]; then
         echo "~~ Test failed in $dir"
         exit 1


### PR DESCRIPTION
- Add `--mount`/`--no-mount` flags to `cowait test`.

If `--mount` is set, the working directory is mounted into the container when running in Docker. Mount is enabled by default.