### PR TITLE
Improve cowait test

### DIFF
--- a/cowait/cli/app/task.py
+++ b/cowait/cli/app/task.py
@@ -157,12 +157,23 @@ def run(
               help='pytest marks',
               type=str,
               default=None)
+@click.option('-v', '--verbose',
+              help='display verbose output',
+              type=bool,
+              default=False)
+@click.option('--capture',
+              help='toggle pytest output capture',
+              type=bool,
+              default=True)
 @click.pass_context
-def test(ctx, cluster: str, mount: bool, cpu: str, cpu_limit: str, memory: str, memory_limit: str, marks: str):
+def test(
+    ctx, cluster: str, mount: bool, cpu: str, cpu_limit: str, memory: str, memory_limit: str,
+    marks: str, verbose: bool, capture: bool,
+):
     cowait.cli.test(
         ctx.obj, cluster_name=cluster, mount=mount,
         cpu=cpu, cpu_limit=cpu_limit, memory=memory, memory_limit=memory_limit,
-        marks=marks,
+        marks=marks, verbose=verbose, capture=capture,
     )
 
 

--- a/cowait/cli/commands/test.py
+++ b/cowait/cli/commands/test.py
@@ -17,6 +17,8 @@ def test(
     memory: str = None,
     memory_limit: str = None,
     marks: str = None,
+    verbose: bool = None,
+    capture: bool = None,
 ):
     logger = TestLogger()
     try:
@@ -51,6 +53,8 @@ def test(
             },
             inputs={
                 'marks': marks,
+                'verbose': verbose,
+                'capture': capture,
             },
             cpu=context.override('cpu', cpu),
             cpu_limit=context.override('cpu_limit', cpu_limit),

--- a/cowait/test/test_task.py
+++ b/cowait/test/test_task.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import asyncio
 from alt_pytest_asyncio.plugin import AltPytestAsyncioPlugin
@@ -5,21 +6,30 @@ from cowait import Task
 
 
 class PytestTask(Task):
-    async def run(self, marks=None):
+    async def run(
+        self,
+        marks=None,
+        verbose: bool = True,
+        capture: bool = True,
+    ):
         plugins = [
             # make sure pytest uses the existing event loop
             AltPytestAsyncioPlugin(loop=asyncio.get_event_loop()),
         ]
 
-        args = [
-            # use cowait's bundled pytest settings
-            "-c", "/var/cowait/pytest.ini",
-        ]
+        # use cowait's bundled pytest config if none is provided in the project root
+        config = None
+        if not os.path.exists('pytest.ini'):
+            config = '/var/cowait/pytest.ini'
 
-        # add pytest marks to args
-        if marks and len(marks) > 0:
-            print('Marks:', marks)
-            args += ["-m", marks]
+        args = create_pytest_args(
+            config=config,
+            verbose=verbose,
+            marks=marks,
+            capture=capture,
+        )
+
+        print('Args:', ' '.join(args))
 
         # run tests
         code = pytest.main(args, plugins=plugins)
@@ -28,3 +38,25 @@ class PytestTask(Task):
         if code != pytest.ExitCode.OK and \
            code != pytest.ExitCode.NO_TESTS_COLLECTED:
             raise RuntimeError('Tests failed')
+
+        return True
+
+
+def create_pytest_args(config=None, marks=None, verbose=True, capture=True):
+    args = []
+
+    if config:
+        args += ['-c', config]
+
+    # verbose output
+    if verbose:
+        args.append('-vv')
+
+    # output capture settings
+    args.append('--capture=' + ('fd' if capture else 'no'))
+
+    # marks
+    if marks and len(marks) > 0:
+        args += ["-m", marks]
+
+    return args


### PR DESCRIPTION
Adds two new flags:
- `--verbose` enables verbose output from pytest (false by default)
- `--capture` toggles output capturing (true by default)

Improved the pytest argument generation code