### PR TITLE
Improve logs command

### DIFF
--- a/cowait/cli/commands/task.py
+++ b/cowait/cli/commands/task.py
@@ -1,6 +1,6 @@
+from cowait.engine import ProviderError
 from ..config import Config
 from ..context import Context
-from cowait.engine import ProviderError
 from .run import RunLogger
 
 
@@ -45,15 +45,16 @@ def logs(config: Config, task_id: str, cluster_name: str, raw: bool = False):
     try:
         context = Context.open(config)
         cluster = context.get_cluster(cluster_name)
-    
+
         logs = cluster.logs(task_id)
         logger = RunLogger(raw)
         logger.id = task_id
         logger.header('task output')
         for msg in logs:
             logger.handle(msg)
+        logger.finalize()
+
         logger.header()
 
     except ProviderError as e:
         print('Provider error:', str(e))
-

--- a/cowait/engine/kubernetes/pod.py
+++ b/cowait/engine/kubernetes/pod.py
@@ -1,4 +1,3 @@
-import json
 from cowait.tasks import TaskDefinition
 from cowait.engine.const import ENV_TASK_DEFINITION
 from cowait.engine.utils import env_unpack


### PR DESCRIPTION
- `logs` command now allows reading logs from terminated Kubernetes pods
- Logs show an error if the task appears to have been lost during execution (i.e. OOM killed or manually deleted)