### PR TITLE
add simple test for kubernetes provider

### DIFF
--- a/cowait/engine/kubernetes/kubernetes.py
+++ b/cowait/engine/kubernetes/kubernetes.py
@@ -29,7 +29,8 @@ class KubernetesProvider(ClusterProvider):
             config.load_incluster_config()
         except kubernetes.config.ConfigException:
             # load local config
-            config.load_kube_config(context=self.args.get('context', None))
+            config.load_kube_config(config_file=self.args.get('kube_config_file', None),
+                                    context=self.args.get('context', None))
 
         self.core = client.CoreV1Api()
         self.ext = client.ExtensionsV1beta1Api()

--- a/test/engine/kubernetes/test_kubernetes.py
+++ b/test/engine/kubernetes/test_kubernetes.py
@@ -1,6 +1,34 @@
 import pytest
+
+import tempfile
 from kubernetes import client
+
 from cowait.engine.kubernetes.volumes import create_volumes
+from cowait.engine.kubernetes import KubernetesProvider
+
+EXAMPLE_KUBE_CONFIG = '''
+current-context: test-context
+apiVersion: v1
+kind: Config
+
+clusters:
+- cluster:
+    api-version: v1
+    server: http://localhost:8080
+  name: test-cluster
+
+users:
+- name: test-user
+  user:
+    token: test-token
+
+contexts:
+- context:
+    cluster: test-cluster
+    namespace: test-ns
+    user: test-user
+  name: test-context
+'''
 
 
 @pytest.mark.kubernetes
@@ -30,3 +58,18 @@ def test_create_volumes():
     assert mount.name == 'volume1'
     assert mount.mount_path == target_path
     assert mount.read_only
+
+
+@pytest.mark.kubernetes
+def test_provider__custom_kube_config():
+    with tempfile.NamedTemporaryFile(mode='w+t') as kube_config_file:
+        kube_config_file.write(EXAMPLE_KUBE_CONFIG)
+        kube_config_file.seek(0)
+
+        provider = KubernetesProvider(args={
+            'context': 'test-context',
+            'namespace': 'the-namespace',
+            'kube_config_file': kube_config_file.name
+        })
+
+        assert provider.namespace == 'the-namespace'  # i.e. NOT 'test-ns' specified in the context


### PR DESCRIPTION
This test fails if the `KubernetesProvider` cannot be instantiated. Such a problem has already happened, and is being addressed by #344.